### PR TITLE
fix: dest fone not required

### DIFF
--- a/src/protocols/Controllers/DFe/NFe/NFEAutorizacao/index.ts
+++ b/src/protocols/Controllers/DFe/NFe/NFEAutorizacao/index.ts
@@ -693,7 +693,7 @@ type EnderDest = {
      * @param {number} fone - Telefone
      * Preencher com o Código DDD + número do telefone. Nas operações com exterior é permitido informar o código do país + código da localidade + número do telefone (v2.0)
      */
-    fone: string;
+    fone?: string;
 }
 
 /**


### PR DESCRIPTION
Caso o destinatário não tenha telefone o desenvolvedor pode omitir a key fone.
Se enviar o fone como vazio, ocorre um erro, mas se omitir é processado com sucesso.