### PR TITLE
Ajuste na config do rollup permitindo inspeção dos nomes originais das variáveis invés de nomes transpilados

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@
     * 
     * MODIFICATION LOG
     * - Version         : 0.2.6
-    * - Date            : 14/11/2024
+    * - Date            : 20/11/2024
     * - Author          : Cassio Seffrin
     * - Modification    : 
 **/
@@ -28,14 +28,13 @@ export default {
         //     sourcemap: true,
         //     compact: true,
         // },
-            {
-                dir: 'dist/cjs',
-                format: 'cjs',
-                sourcemap: true,
-                sourcemapFile: 'dist/cjs/index.js.map',
-                compact: true,
-                inlineSources: true,
-            },
+        {
+            dir: 'dist/cjs',
+            format: 'cjs',
+            sourcemap: true,
+            compact: true,
+            inlineSources: true,
+        },
     ],
     external: ['fs', 'path', 'https', 'url', 'crypto', 'bwip-js', 'xsd-schema-validator', 'pdfkit', 'pem', 'libxmljs'],
     plugins: [
@@ -44,16 +43,19 @@ export default {
                 { find: '@Classes', replacement: path.resolve(__dirname, 'src/classes') },
                 { find: '@Controllers', replacement: path.resolve(__dirname, 'src/controllers') },
                 { find: '@Protocols', replacement: path.resolve(__dirname, 'src/protocols') },
-                { find: '@Protocols', replacement: path.resolve(__dirname, 'src/protocols/index') },
                 { find: '@Utils', replacement: path.resolve(__dirname, 'src/utils') },
             ],
         }),
         json(),
         nodeResolve(),
         commonjs(),
-        typescript(),
+        typescript({
+            tsconfig: "tsconfig.json",
+            useTsconfigDeclarationDir: true,
+            sourceMap: true,
+        }),
         replace({
-            'process.env.NODE_ENV': JSON.stringify('production'), // Substitui NODE_ENV por 'production'
+            'process.env.NODE_ENV': JSON.stringify('production'),
             preventAssignment: true,
         }),
         copy({
@@ -68,6 +70,9 @@ export default {
                 { src: 'src/schemas/*', dest: 'dist/cjs/schemas' },
             ],
         }),
-        terser(),
+        terser({
+            keep_fnames: true,
+            mangle: false,
+        }),
     ],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,8 +20,6 @@
     "moduleResolution": "Node",
     "resolveJsonModule": true,
     "baseUrl": ".", // Define o diretório base para resolução de módulos
-    "inlineSources": true,
-    "inlineSourceMap": false,
     "paths": {
       "@Classes/*": [
         "src/classes/*"


### PR DESCRIPTION
Agora é possível inspecionar corretamente, no projeto que importa o NfeWizard-IO, os nomes originais e os valores das variáveis da biblioteca. Essa melhoria permite realizar um debug mais preciso, possibilitando a inspeção detalhada, além de adicionar watches, expressões e outros recursos de depuração.

Segue uma ilustração:


<img width="2024" alt="nomesVariaviesOk" src="https://github.com/user-attachments/assets/4d2fcd91-75bc-4902-b5f9-0b50e098c5a7">

