### PR TITLE
Correção da URL de homologação para SC

### DIFF
--- a/src/core/config/NFeServicosUrl.json
+++ b/src/core/config/NFeServicosUrl.json
@@ -1150,7 +1150,7 @@
     "URL-ConsultaNFCe_2.00": "https://sat.sef.sc.gov.br/nfce/consulta"
   },
   "NFCe_SC_H": {
-    "Usar": "NFCe_SP_H",
+    "Usar": "NFCe_SVRS_H",
     "URL-QRCode": "https://hom.sat.sef.sc.gov.br/nfce/consulta?p=",
     "URL-ConsultaNFCe": "https://hom.sat.sef.sc.gov.br/nfce/consulta",
     "URL-ConsultaNFCe_2.00": "https://hom.sat.sef.sc.gov.br/nfce/consulta"


### PR DESCRIPTION
Corrigida a URL de homologação para o estado de Santa Catarina (SC) no arquivo NFeServicosUrl.json. A alteração assegura que as URLs de consulta e QRCode de NFCe estejam corretamente apontando para o ambiente de homologação de SC.

Marco, poderia me dizer qual dos scripts de build você executa quando faz o build e deploy para npmjs.com/package/nfewizard-io? 

Após as atualizações da versao 0.3.4 não consegui mais fazer deploy local com npm link, quando instado com: yarn add  nfewizard-io@0.3.4 que é a última versão do npmjs.com o projeto funciona, porem quando aponto para meu diretório local con npm link recebo muitos erros como se fosse que a lib nao foi encontrada.

Não sei exatamente como o deploy lá no npmjs funciona.

Obrigado,
Cassio

