### PR TITLE
Refactor(DANFE): Otimiza barcode para buffer e ajusta renderização de bairro longo

### DIFF
--- a/src/modules/dfe/danfe/NFEGerarDanfe/NFEGerarDanfe.ts
+++ b/src/modules/dfe/danfe/NFEGerarDanfe/NFEGerarDanfe.ts
@@ -394,10 +394,46 @@ class NFEGerarDanfe {
             this.doc.fontSize(5).text('BAIRRO / DISTRITO', left + 324, topDestinatario + 148, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(String(this.dest?.enderDest?.xBairro  || ''), left + 326, topDestinatario + 158, {
-                characterSpacing: 1,
+
+            const bairroText = String(this.dest?.enderDest?.xBairro || '');
+            const bairroCharLimit = 22;
+            const bairroMaxWidthForText = 110; // Largura útil para o texto dentro da célula
+            const defaultBairroFontSize = 8;
+            const reducedBairroFontSize = 5.5;
+            const defaultBairroCharSpacing = 1;
+            const reducedBairroCharSpacing = 0.25;
+
+            let fontSizeToUse = defaultBairroFontSize;
+            let charSpacingToUse = defaultBairroCharSpacing;
+
+            if (bairroText.length > bairroCharLimit) {
+                fontSizeToUse = reducedBairroFontSize;
+                charSpacingToUse = reducedBairroCharSpacing;
+            }
+
+            // Cálculo de Y para tentar alinhar (pode precisar de ajuste fino)
+            const textLineHeight = this.doc.currentLineHeight(); // Altura da linha com fontSizeToUse
+            const cellContentYBase = topDestinatario + 158; // Linha de base original
+            const cellHeightForText = 23 - 5 - 5; // Altura da célula - padding label - padding inferior
+            let yPosForBairro = cellContentYBase; 
+            // Ajuste simples para tentar centralizar um pouco se a linha for mais baixa que o espaço
+            if (textLineHeight < cellHeightForText) {
+                 yPosForBairro = cellContentYBase - ((cellHeightForText - textLineHeight) / 2) + (textLineHeight*0.3) ; // ajuste
+            }
+             // Ajuste fino para alinhar com os outros campos na mesma linha Y
+            yPosForBairro = topDestinatario + 158; // Reset para a mesma linha Y dos outros campos
+
+            this.doc.font('Times-Roman').fontSize(fontSizeToUse);
+
+            this.doc.text(bairroText, left + 320 + 3, yPosForBairro, { // Padding X de 3pt
+                characterSpacing: charSpacingToUse,
+                width: bairroMaxWidthForText,
+                lineBreak: false,
+                ellipsis: true,
             });
 
+            this.doc.font('Times-Roman').fontSize(8);
+            
             this.doc.rect(left + 438.5, topDestinatario + 143, 53.5, 23).stroke();
             this.doc.fontSize(5).text('CEP', left + 442.5, topDestinatario + 148, {
                 characterSpacing: 0.5,


### PR DESCRIPTION
Este Pull Request implementa duas melhorias principais na geração do DANFE (NFEGerarDanfe):

1.  **Geração de Código de Barras em Buffer:**
    *   Substitui a geração do código de barras (Code128) que usava um arquivo temporário (`barcode.png`) por uma geração direta em buffer na memória utilizando `bwipjs.toBuffer()`.
    *   O buffer da imagem é enviado diretamente ao PDFKit, eliminando operações de I/O desnecessárias e evitando potenciais erros de escrita/leitura de arquivos temporários (como `ENOENT: no such file or directory`).

2.  **Ajuste na Renderização de Bairro/Distrito Longo:**
    *   Corrige a quebra de layout no campo "BAIRRO / DISTRITO" na seção do Destinatário quando o texto é extenso.
    *   A lógica agora verifica o comprimento do nome do bairro:
        *   Até 22 caracteres: mantém fonte padrão (8pt).
        *   Acima de 22 caracteres: reduz a fonte (para 5.5pt) e o espaçamento entre caracteres.
        *   Ellipsis (`...`) é aplicado como fallback se o texto ainda exceder a largura da célula.
    *   Isso previne que o texto do bairro invada células adjacentes. A fonte do documento é restaurada após este campo.


## Como Testar

**Para Barcode em Buffer:**
1.  Gerar um DANFE.
2.  Verificar se o código de barras é exibido corretamente no PDF.
3.  Confirmar que nenhum arquivo `barcode.png` temporário é criado no sistema de arquivos durante o processo.

**Para Ajuste do Bairro:**
1.  Gerar um DANFE para um destinatário com um nome de bairro/distrito curto (menos de 22 caracteres). Verificar se a fonte está normal (8pt).
2.  Gerar um DANFE para um destinatário com um nome de bairro/distrito longo (mais de 22 caracteres). Verificar se a fonte foi reduzida (para 5.5pt) e se o texto está contido na célula.
3.  Verificar se os campos vizinhos (CEP, Data Saída/Entrada) mantiveram sua formatação original.

---
*Nota: A geração de QRCode no NFCEGerarDanfe permanece inalterada e será tratada separadamente. (Segue Usando /tmp para guardar em disco o barcode.png e pode quebrar em produção)*