### PR TITLE
Correção da tipagem vTotTrib na tag <det> como string.

### DIFF
--- a/src/core/types/NFEAutorizacao.ts
+++ b/src/core/types/NFEAutorizacao.ts
@@ -1,3 +1,15 @@
+/**
+    * @description      : 
+    * @author           : Marco Aurélio Silva Lima 
+    * @group            : 
+    * @created          : 28/07/2025 - 21:43:03
+    * 
+    * MODIFICATION LOG
+    * - Version         : 1.0.0
+    * - Date            : 28/07/2025
+    * - Author          : Cassio Seffrin
+    * - Modification    : 
+**/
 /*
  * This file is part of NFeWizard-io.
  * 
@@ -1294,9 +1306,9 @@ export type Imposto = {
      */
     impostoDevol?: impostoDevol;
     /**
-     * @param {number} vTotTrib - Valor aproximado total de tributos federais, estaduais e municipais.
+     * @param {string} vTotTrib - Valor aproximado total de tributos federais, estaduais e municipais.
      */
-    vTotTrib?: number;
+    vTotTrib?: string;
 }
 
 /**


### PR DESCRIPTION
Boa noite Marco,

A tipagem vTotTrib como number na tag DET estava causando esta rejeição:

NFCE_ Autorizacao: Erro na Validação do XML: cvc-pattern-valid na linha 1, coluna 1420. Descrição: Value '50.6' is not facet-valid with respect to pattern '0|01.[0-9K2)[1-9K1H[0-9K0,12)(.[0-9K2})7' for type 'TDec_1302'.

A Sefaz exige 2 casas decimais, portanto 50.60 invés de 50.6. Deste modo é necessário utilização de tipagem string.

Utilizei o site de olho no imposto para calcular o valor, que se aplica individualmente a cada produto e depois nos totais. Nos totais ja estava como string, portanto foi ajustado somente na tag <det>

Atenciosamente,
Cassio