### PR TITLE
Remove ?wsdl das URLs de SEFAZ PE

### DIFF
--- a/src/core/config/NFeServicosUrl.json
+++ b/src/core/config/NFeServicosUrl.json
@@ -342,8 +342,8 @@
     "NFEStatusServico_3.10": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NfeStatusServico2",
     "NfeConsultaCadastro_2.00": "https://nfe.sefaz.pe.gov.br/nfe-service/services/CadConsultaCadastro2",
     "NfeConsultaCadastro_3.10": "https://nfe.sefaz.pe.gov.br/nfe-service/services/CadConsultaCadastro2",
-    "NFEAutorizacao_3.10": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NfeAutorizacao?wsdl",
-    "NFERetornoAutorizacao_3.10": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NfeRetAutorizacao?wsdl",
+    "NFEAutorizacao_3.10": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NfeAutorizacao",
+    "NFERetornoAutorizacao_3.10": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NfeRetAutorizacao",
     "NFEInutilizacao_4.00": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NFeInutilizacao4",
     "NFEConsultaProtocolo_4.00": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NFeConsultaProtocolo4",
     "NFEStatusServico_4.00": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NFeStatusServico4",
@@ -351,7 +351,7 @@
     "NFEAutorizacao_4.00": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NFeAutorizacao4",
     "NFERetornoAutorizacao_4.00": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NFeRetAutorizacao4",
     "NfeConsultaCadastro_4.00": "https://nfe.sefaz.pe.gov.br/nfe-service/services/CadConsultaCadastro4",
-    "NFERetAutorizacao_3.10": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NfeRetAutorizacao?wsdl",
+    "NFERetAutorizacao_3.10": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NfeRetAutorizacao",
     "NFERetAutorizacao_4.00": "https://nfe.sefaz.pe.gov.br/nfe-service/services/NFeRetAutorizacao4"
   },
   "NFe_PE_H": {
@@ -364,17 +364,17 @@
     "NFEConsultaProtocolo_3.10": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NfeConsulta2",
     "NFEStatusServico_2.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NfeStatusServico2",
     "NFEStatusServico_3.10": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NfeStatusServico2",
-    "NFEAutorizacao_3.10": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NfeAutorizacao?wsdl",
-    "NFERetornoAutorizacao_3.10": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NfeRetAutorizacao?wsdl",
-    "NFEInutilizacao_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeInutilizacao4?wsdl",
-    "NFEConsultaProtocolo_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeConsultaProtocolo4?wsdl",
-    "NFEStatusServico_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeStatusServico4?wsdl",
-    "NfeConsultaCadastro_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/CadConsultaCadastro4?wsdl",
-    "RecepcaoEvento_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeRecepcaoEvento4?wsdl",
-    "NFEAutorizacao_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeAutorizacao4?wsdl",
-    "NFERetornoAutorizacao_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeRetAutorizacao4?wsdl",
-    "NFERetAutorizacao_3.10": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NfeRetAutorizacao?wsdl",
-    "NFERetAutorizacao_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeRetAutorizacao4?wsdl"
+    "NFEAutorizacao_3.10": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NfeAutorizacao",
+    "NFERetornoAutorizacao_3.10": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NfeRetAutorizacao",
+    "NFEInutilizacao_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeInutilizacao4",
+    "NFEConsultaProtocolo_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeConsultaProtocolo4",
+    "NFEStatusServico_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeStatusServico4",
+    "NfeConsultaCadastro_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/CadConsultaCadastro4",
+    "RecepcaoEvento_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeRecepcaoEvento4",
+    "NFEAutorizacao_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeAutorizacao4",
+    "NFERetornoAutorizacao_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeRetAutorizacao4",
+    "NFERetAutorizacao_3.10": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NfeRetAutorizacao",
+    "NFERetAutorizacao_4.00": "https://nfehomolog.sefaz.pe.gov.br/nfe-service/services/NFeRetAutorizacao4"
   },
   "NFe_PI_P": {
     "Usar": "NFe_SVRS_P"


### PR DESCRIPTION
Esse PR remove os ?wsdl das URLs do serviço de NFe do estado de Pernambuco (PE) nas configurações de ambiente de homologação e produção.

O ?wsdl não é necessário para realizar as requisições SOAP de envio e consulta de status, e sua presença estava causando erro 500 ao tentar consultar o status do serviço da SEFAZ.

Com essa alteração:

As URLs passam a apontar diretamente para o endpoint correto do webservice;

Erros relacionados a envio de requisições para o WSDL devem ser eliminados;

Mantida compatibilidade com os outros estados e serviços que não foram alterados.