### PR TITLE
Corrige falha ao gerar DANFE para NF-e com grupo IPI/IPINT, onde IPITrib não existe e o acesso a IPI.IPITrib.vIPI causava erro.

### DIFF
--- a/packages/danfe/src/generators/NFEGerarDanfe.ts
+++ b/packages/danfe/src/generators/NFEGerarDanfe.ts
@@ -1007,10 +1007,10 @@ class NFeGerarDanfe {
                 return { vBC, vICMS, pICMS };
             }
             function getValoresIPI(IPI: IPI | undefined): { vIPI: string, pIPI: string } {
-                if (!IPI) {
+                if (!IPI || !IPI.IPITrib) {
                     return {
-                        vIPI: '0,00',
-                        pIPI: '0,00'
+                        vIPI: '0.00',
+                        pIPI: '0.00'
                     }
                 }
 


### PR DESCRIPTION
## Parametrizacao

- Tipo de DANFE: NFe

## Logs Relevantes

```json
{
  "context": "DANFE_NFe",
  "error": {
    "message": "Erro ao gerar PDF",
    "details": "Cannot read properties of undefined (reading 'vIPI')"
  }
}
```

## Descricao

Corrige erro na geracao de DANFE para NF-e quando o XML possui grupo de IPI nao tributado (`IPINT`) em vez de `IPITrib`.

O leiaute da NF-e permite, dentro de `<IPI>`, a escolha entre `IPITrib` e `IPINT`. Para CSTs como `52` (`Saida isenta`), o grupo correto e `IPINT`, e os campos `vIPI` e `pIPI` nao existem.

Antes da correcao, a geracao acessava diretamente:

```ts
IPI.IPITrib.vIPI
IPI.IPITrib.pIPI
```

Isso causava excecao quando `IPITrib` estava ausente.

## Correcao

A funcao `getValoresIPI` agora retorna `0.00` para valor e aliquota quando:

- `IPI` nao existe
- `IPI` existe, mas nao possui `IPITrib`, como no caso de `IPINT`

## Comportamento Esperado

NF-e com IPI nao tributado deve gerar DANFE normalmente, exibindo IPI como `0.00`, sem lancar excecao.