### PR TITLE
fix: Corrigir campos PESO BRUTO e PESO LÍQUIDO no bloco de transporte da DANFE

### DIFF
--- a/packages/danfe/src/generators/NFEGerarDanfe.ts
+++ b/packages/danfe/src/generators/NFEGerarDanfe.ts
@@ -489,7 +489,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('INSCRIÇÃO ESTADUAL', left + 403.5, topDestinatario + 171, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(String(this.dest?.indIEDest || ''), left + 403.5, topDestinatario + 181, {
+            this.doc.fontSize(8).text(String(this.dest?.IE || ''), left + 403.5, topDestinatario + 181, {
                 characterSpacing: 1,
             });
 

--- a/packages/danfe/src/generators/NFEGerarDanfe.ts
+++ b/packages/danfe/src/generators/NFEGerarDanfe.ts
@@ -1042,7 +1042,7 @@ class NFeGerarDanfe {
             });
 
             this.doc.rect(left + 178, top, 30, itemHeight).stroke();
-            this.doc.text(String(item.prod.NCM) || ''), left + 178, top + 5.9, {
+            this.doc.text(String(item.prod.NCM || ''), left + 178, top + 5.9, {
                 width: 30,
                 align: 'center'
             });

--- a/packages/danfe/src/generators/NFEGerarDanfe.ts
+++ b/packages/danfe/src/generators/NFEGerarDanfe.ts
@@ -1175,9 +1175,9 @@ class NFeGerarDanfe {
         this.doc.fontSize(5).text('RESERVADO AO FISCO', 408 + 10, topDestinatario + 4.5, {
             characterSpacing: 0.5
         });
-        this.doc.fontSize(8).text(String(this.infAdic?.infAdFisco || ''), 13, topDestinatario + 13, {
+        this.doc.fontSize(8).text(String(this.infAdic?.infAdFisco || ''), left + 408 + 10, topDestinatario + 13, {
             characterSpacing: 1,
-            width: 400,
+            width: 138,
         });
 
         if (this.exibirMarcaDaguaDanfe) {

--- a/packages/danfe/src/generators/NFEGerarDanfe.ts
+++ b/packages/danfe/src/generators/NFEGerarDanfe.ts
@@ -456,7 +456,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('DATA SAÍDA / ENTRADA', left + 496, topDestinatario + 148, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(format(new Date(), 'dd-MM-yyyy'), left + 497, topDestinatario + 158, {
+            this.doc.fontSize(8).text(this.ide.dhSaiEnt ? format(new Date(this.ide.dhSaiEnt), 'dd-MM-yyyy') : '', left + 497, topDestinatario + 158, {
                 characterSpacing: 1,
             });
         }
@@ -497,7 +497,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('HORA DA SAÍDA', left + 496, topDestinatario + 171, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(format(new Date(), 'HH:mm'), left + 497, topDestinatario + 181, {
+            this.doc.fontSize(8).text(this.ide.dhSaiEnt ? format(new Date(this.ide.dhSaiEnt), 'HH:mm') : '', left + 497, topDestinatario + 181, {
                 characterSpacing: 1,
             });
         }

--- a/packages/danfe/src/generators/NFEGerarDanfe.ts
+++ b/packages/danfe/src/generators/NFEGerarDanfe.ts
@@ -713,7 +713,7 @@ class NFeGerarDanfe {
                     this.doc.fontSize(5).text('PESO BRUTO', left + 374, topTrnasportTitle, {
                         characterSpacing: 0.5,
                     });
-                    this.doc.fontSize(8).text(String(vol?.nVol || ''), left + 375, topTrnasportValue, {
+                    this.doc.fontSize(8).text(String(vol?.pesoB || ''), left + 375, topTrnasportValue, {
                         characterSpacing: 1,
                     });
                     //96,43
@@ -721,7 +721,7 @@ class NFeGerarDanfe {
                     this.doc.fontSize(5).text('PESO LÍQUIDO', left + 474.5, topTrnasportTitle, {
                         characterSpacing: 0.5,
                     });
-                    this.doc.fontSize(8).text(String(vol?.nVol || ''), left + 475.5, topTrnasportValue, {
+                    this.doc.fontSize(8).text(String(vol?.pesoL || ''), left + 475.5, topTrnasportValue, {
                         characterSpacing: 1,
                     });
                     /** Define posição da nova linha */

--- a/packages/danfe/src/generators/NFEGerarDanfe.ts
+++ b/packages/danfe/src/generators/NFEGerarDanfe.ts
@@ -999,7 +999,7 @@ class NFeGerarDanfe {
                         pICMS = (ICMS[tipoICMS] as any).pICMS
                  return {
                             vBC: parseFloat(vBC).toFixed(2),
-                            vICMS: parseFloat(vBC).toFixed(2),
+                            vICMS: parseFloat(vICMS).toFixed(2),
                             pICMS: parseFloat(pICMS).toFixed(2)
                  };
                     }

--- a/packages/danfe/src/generators/NFEGerarDanfe.ts
+++ b/packages/danfe/src/generators/NFEGerarDanfe.ts
@@ -124,6 +124,18 @@ class NFeGerarDanfe {
         this._buildFooter();
     }
 
+    formatDecimal(value: string | number | undefined | null, minimumFractionDigits = 2, maximumFractionDigits = 2): string {
+        const valueText = String(value ?? '0').trim();
+        const normalizedValue = valueText.includes(',') ? valueText.replace(/\./g, '').replace(',', '.') : valueText;
+        const parsedValue = parseFloat(normalizedValue);
+        const numericValue = Number.isNaN(parsedValue) ? 0 : parsedValue;
+
+        return numericValue.toLocaleString('pt-BR', {
+            minimumFractionDigits,
+            maximumFractionDigits,
+        });
+    }
+
     _buildGuia() {
         const { top, left } = this.doc.page.margins;
         this.setLineStyle(0.75, '#1c1c1c');
@@ -133,7 +145,7 @@ class NFeGerarDanfe {
         this.doc.fontSize(5).text(`RECEBEMOS DE ${this.emit.xNome} OS PRODUTOS / SERVIÇOS CONSTANTES DA NOTA FISCAL INDICADO AO LADO`, 10, 26, {
             characterSpacing: 0.5
         });
-        this.doc.fontSize(6).text(`EMISSÃO: ${format(new Date(this.ide.dhEmi), 'dd-MM-yyyy')} -  DEST. / REM.: ${this.dest?.xNome || ''}  -  VALOR TOTAL: R$ ${parseFloat(String(this.total.ICMSTot.vNF)).toFixed(2)}`, 10, 33.5, {
+        this.doc.fontSize(6).text(`EMISSÃO: ${format(new Date(this.ide.dhEmi), 'dd-MM-yyyy')} -  DEST. / REM.: ${this.dest?.xNome || ''}  -  VALOR TOTAL: R$ ${this.formatDecimal(this.total.ICMSTot.vNF)}`, 10, 33.5, {
             characterSpacing: 0.5
         });
         /** RIGHT */
@@ -522,7 +534,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).font('Times-Roman').text('BASE DE CÁLCULO DO ICMS', left + 4, topDestinatario + 125, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(parseFloat(String(this.total.ICMSTot.vBC)).toFixed(2), left - 8, topDestinatario + 135, {
+            this.doc.fontSize(8).text(this.formatDecimal(this.total.ICMSTot.vBC), left - 8, topDestinatario + 135, {
                 characterSpacing: 1,
                 align: 'right',
                 width: 86
@@ -531,7 +543,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('VALOR DO ICMS', left + 90, topDestinatario + 125, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(parseFloat(String(this.total.ICMSTot.vICMS)).toFixed(2), left + 86 - 16, topDestinatario + 135, {
+            this.doc.fontSize(8).text(this.formatDecimal(this.total.ICMSTot.vICMS), left + 86 - 16, topDestinatario + 135, {
                 characterSpacing: 1,
                 align: 'right',
                 width: 86
@@ -540,7 +552,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('BASE CÁLC. ICMS SUBST', left + 169, topDestinatario + 125, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(parseFloat(String(this.total.ICMSTot.vBCST)).toFixed(2), left + 165 - 16, topDestinatario + 135, {
+            this.doc.fontSize(8).text(this.formatDecimal(this.total.ICMSTot.vBCST), left + 165 - 16, topDestinatario + 135, {
                 characterSpacing: 1,
                 align: 'right',
                 width: 86
@@ -549,7 +561,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('VALOR DO ICMS SUBST.', left + 248, topDestinatario + 125, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(parseFloat(String(this.total.ICMSTot.vST)).toFixed(2), left + 244 - 16, topDestinatario + 135, {
+            this.doc.fontSize(8).text(this.formatDecimal(this.total.ICMSTot.vST), left + 244 - 16, topDestinatario + 135, {
                 characterSpacing: 1,
                 align: 'right',
                 width: 86
@@ -558,7 +570,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('VALOR APROX. DOS TRIBUTOS', left + 327, topDestinatario + 125, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(parseFloat(this.total.ICMSTot.vTotTrib || '0').toFixed(2), left + 323 - 6, topDestinatario + 135, {
+            this.doc.fontSize(8).text(this.formatDecimal(this.total.ICMSTot.vTotTrib), left + 323 - 6, topDestinatario + 135, {
                 characterSpacing: 1,
                 align: 'right',
                 width: 86
@@ -568,7 +580,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('VALOR TOTAL DOS PRODUTOS', left + 418, topDestinatario + 125, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(parseFloat(String(this.total.ICMSTot.vProd)).toFixed(2), left + 480 - 8, topDestinatario + 135, {
+            this.doc.fontSize(8).text(this.formatDecimal(this.total.ICMSTot.vProd), left + 480 - 8, topDestinatario + 135, {
                 characterSpacing: 1,
                 align: 'right',
                 width: 86
@@ -579,7 +591,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('VALOR DO FRETE', left + 4, topDestinatario + 148, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(parseFloat(String(this.total.ICMSTot.vFrete)).toFixed(2), left - 8, topDestinatario + 158, {
+            this.doc.fontSize(8).text(this.formatDecimal(this.total.ICMSTot.vFrete), left - 8, topDestinatario + 158, {
                 characterSpacing: 1,
                 align: 'right',
                 width: 86
@@ -589,7 +601,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('VALOR DO SEGURO', left + 90, topDestinatario + 148, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(parseFloat(String(this.total.ICMSTot.vSeg)).toFixed(2), left + 86 - 16, topDestinatario + 158, {
+            this.doc.fontSize(8).text(this.formatDecimal(this.total.ICMSTot.vSeg), left + 86 - 16, topDestinatario + 158, {
                 characterSpacing: 1,
                 align: 'right',
                 width: 86
@@ -598,7 +610,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('DESCONTO', left + 169, topDestinatario + 148, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(parseFloat(String(this.total.ICMSTot.vDesc)).toFixed(2), left + 165 - 16, topDestinatario + 158, {
+            this.doc.fontSize(8).text(this.formatDecimal(this.total.ICMSTot.vDesc), left + 165 - 16, topDestinatario + 158, {
                 characterSpacing: 1,
                 align: 'right',
                 width: 86
@@ -607,7 +619,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('OUTRAS DESP. ACESS.', left + 248, topDestinatario + 148, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(parseFloat(String(this.total.ICMSTot.vOutro)).toFixed(2), left + 244 - 16, topDestinatario + 158, {
+            this.doc.fontSize(8).text(this.formatDecimal(this.total.ICMSTot.vOutro), left + 244 - 16, topDestinatario + 158, {
                 characterSpacing: 1,
                 align: 'right',
                 width: 86
@@ -616,7 +628,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('VALOR DO IPI', left + 327, topDestinatario + 148, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(parseFloat(String(this.total.ICMSTot.vIPI)).toFixed(2), left + 323 - 6, topDestinatario + 158, {
+            this.doc.fontSize(8).text(this.formatDecimal(this.total.ICMSTot.vIPI), left + 323 - 6, topDestinatario + 158, {
                 characterSpacing: 1,
                 align: 'right',
                 width: 86
@@ -626,7 +638,7 @@ class NFeGerarDanfe {
             this.doc.fontSize(5).text('VALOR TOTAL DA NOTA', left + 418, topDestinatario + 148, {
                 characterSpacing: 0.5,
             });
-            this.doc.fontSize(8).text(parseFloat(String(this.total.ICMSTot.vNF)).toFixed(2), left + 480 - 8, topDestinatario + 158, {
+            this.doc.fontSize(8).text(this.formatDecimal(this.total.ICMSTot.vNF), left + 480 - 8, topDestinatario + 158, {
                 characterSpacing: 1,
                 align: 'right',
                 width: 86
@@ -713,7 +725,7 @@ class NFeGerarDanfe {
                     this.doc.fontSize(5).text('PESO BRUTO', left + 374, topTrnasportTitle, {
                         characterSpacing: 0.5,
                     });
-                    this.doc.fontSize(8).text(String(vol?.pesoB || ''), left + 375, topTrnasportValue, {
+                    this.doc.fontSize(8).text(vol?.pesoB ? this.formatDecimal(vol.pesoB, 3, 3) : '', left + 375, topTrnasportValue, {
                         characterSpacing: 1,
                     });
                     //96,43
@@ -721,7 +733,7 @@ class NFeGerarDanfe {
                     this.doc.fontSize(5).text('PESO LÍQUIDO', left + 474.5, topTrnasportTitle, {
                         characterSpacing: 0.5,
                     });
-                    this.doc.fontSize(8).text(String(vol?.pesoL || ''), left + 475.5, topTrnasportValue, {
+                    this.doc.fontSize(8).text(vol?.pesoL ? this.formatDecimal(vol.pesoL, 3, 3) : '', left + 475.5, topTrnasportValue, {
                         characterSpacing: 1,
                     });
                     /** Define posição da nova linha */
@@ -941,6 +953,8 @@ class NFeGerarDanfe {
         };
 
         const row = (top: number, item: DetProd) => {
+            const formatDecimal = this.formatDecimal.bind(this);
+
             function getCST(ICMS: ICMS): string {
                 const chavesICMS: (keyof ICMS)[] = Object.keys(ICMS) as (keyof ICMS)[];
 
@@ -998,9 +1012,9 @@ class NFeGerarDanfe {
                         vICMS = (ICMS[tipoICMS] as any).vICMS
                         pICMS = (ICMS[tipoICMS] as any).pICMS
                  return {
-                            vBC: parseFloat(vBC).toFixed(2),
-                            vICMS: parseFloat(vICMS).toFixed(2),
-                            pICMS: parseFloat(pICMS).toFixed(2)
+                            vBC: formatDecimal(vBC),
+                            vICMS: formatDecimal(vICMS),
+                            pICMS: formatDecimal(pICMS)
                  };
                     }
                 }
@@ -1014,8 +1028,8 @@ class NFeGerarDanfe {
                     }
                 }
 
-                let vIPI = parseFloat(String(IPI.IPITrib.vIPI)).toFixed(2);
-                let pIPI = parseFloat(String(IPI.IPITrib.pIPI)).toFixed(2);
+                let vIPI = formatDecimal(IPI.IPITrib.vIPI);
+                let pIPI = formatDecimal(IPI.IPITrib.pIPI);
                 return { vIPI, pIPI }
             }
             const CST = getCST(item.imposto.ICMS as ICMS);

--- a/packages/danfe/src/generators/NFEGerarDanfe.ts
+++ b/packages/danfe/src/generators/NFEGerarDanfe.ts
@@ -1170,6 +1170,8 @@ class NFeGerarDanfe {
         this.doc.fontSize(8).text(this.infAdic?.infCpl || '', 13, topDestinatario + 13, {
             characterSpacing: 1,
             width: 400,
+            height: 82,
+            lineBreak: true,
         });
         this.doc.rect(left + 408, topDestinatario, 158.93, 95).stroke();
         this.doc.fontSize(5).text('RESERVADO AO FISCO', 408 + 10, topDestinatario + 4.5, {
@@ -1178,6 +1180,8 @@ class NFeGerarDanfe {
         this.doc.fontSize(8).text(String(this.infAdic?.infAdFisco || ''), left + 408 + 10, topDestinatario + 13, {
             characterSpacing: 1,
             width: 138,
+            height: 82,
+            lineBreak: true,
         });
 
         if (this.exibirMarcaDaguaDanfe) {

--- a/packages/danfe/src/generators/NFEGerarDanfe.ts
+++ b/packages/danfe/src/generators/NFEGerarDanfe.ts
@@ -1042,7 +1042,7 @@ class NFeGerarDanfe {
             });
 
             this.doc.rect(left + 178, top, 30, itemHeight).stroke();
-            this.doc.text(String(item.prod.NCM) || '', left + 178, top + 5.9, {
+            this.doc.text(String(item.prod.NCM) || ''), left + 178, top + 5.9, {
                 width: 30,
                 align: 'center'
             });


### PR DESCRIPTION
**Problema**
No bloco de transporte da DANFE (NF-e), os campos PESO BRUTO e PESO LÍQUIDO estão sendo renderizados com o valor de vol.nVol (numeração do volume) em vez dos campos corretos do XML (vol.pesoB e vol.pesoL).

Como a maioria dos XMLs de NF-e não inclui a tag <nVol>, o resultado é que ambos os campos aparecem vazios no PDF, mesmo quando <pesoB> e <pesoL> estão corretamente presentes no XML.

**Causa**
Em packages/danfe/src no método createVolume, as três últimas colunas do bloco de transporte (NUMERAÇÃO, PESO BRUTO e PESO LÍQUIDO) referenciam `vol?.nVol`.

Correção

**PESO BRUTO**
```
- this.doc.fontSize(8).text(String(vol?.nVol || ''), left + 375, topTrnasportValue, {
+ this.doc.fontSize(8).text(String(vol?.pesoB || ''), left + 375, topTrnasportValue, {
```

**PESO LÍQUIDO**
```
- this.doc.fontSize(8).text(String(vol?.nVol || ''), left + 475.5, topTrnasportValue, {
+ this.doc.fontSize(8).text(String(vol?.pesoL || ''), left + 475.5, topTrnasportValue, {
```

XML de exemplo

```
<transp>
  <vol>
    <qVol>1</qVol>
    <pesoL>0.500</pesoL>
    <pesoB>0.500</pesoB>
  </vol>
</transp>
```