### PR TITLE
fix(shared): NFC-e CE QR Code URL pointed to the SC portal (homolog) + missing 2.00 entry (prod)

### DIFF
--- a/packages/shared/src/config/NFeServicosUrl.json
+++ b/packages/shared/src/config/NFeServicosUrl.json
@@ -811,13 +811,14 @@
   },
   "NFCe_CE_P": {
     "Usar": "NFCe_SVRS_P",
+    "URL-QRCode_2.00": "http://nfce.sefaz.ce.gov.br/pages/ShowNFCe.html",
     "URL-QRCode": "http://nfce.sefaz.ce.gov.br/pages/ShowNFCe.html",
     "URL-ConsultaNFCe": "http://nfce.sefaz.ce.gov.br/pages/consultaChaveAcesso.jsf",
     "URL-ConsultaNFCe_2.00": "www.sefaz.ce.gov.br/nfce/consulta"
   },
   "NFCe_CE_H": {
     "Usar": "NFCe_SVRS_H",
-    "URL-QRCode_2.00": "https://hom.sat.sef.sc.gov.br/nfce/consulta",
+    "URL-QRCode_2.00": "http://nfceh.sefaz.ce.gov.br/pages/ShowNFCe.html",
     "URL-QRCode": "http://nfceh.sefaz.ce.gov.br/pages/ShowNFCe.html",
     "URL-ConsultaNFCe": "http://nfceh.sefaz.ce.gov.br/pages/consultaChaveAcesso.jsf",
     "URL-ConsultaNFCe_2.00": "www.sefaz.ce.gov.br/nfce/consulta",

--- a/packages/shared/src/core/config/NFeServicosUrl.json
+++ b/packages/shared/src/core/config/NFeServicosUrl.json
@@ -811,13 +811,14 @@
   },
   "NFCe_CE_P": {
     "Usar": "NFCe_SVRS_P",
+    "URL-QRCode_2.00": "http://nfce.sefaz.ce.gov.br/pages/ShowNFCe.html",
     "URL-QRCode": "http://nfce.sefaz.ce.gov.br/pages/ShowNFCe.html",
     "URL-ConsultaNFCe": "http://nfce.sefaz.ce.gov.br/pages/consultaChaveAcesso.jsf",
     "URL-ConsultaNFCe_2.00": "www.sefaz.ce.gov.br/nfce/consulta"
   },
   "NFCe_CE_H": {
     "Usar": "NFCe_SVRS_H",
-    "URL-QRCode_2.00": "https://hom.sat.sef.sc.gov.br/nfce/consulta",
+    "URL-QRCode_2.00": "http://nfceh.sefaz.ce.gov.br/pages/ShowNFCe.html",
     "URL-QRCode": "http://nfceh.sefaz.ce.gov.br/pages/ShowNFCe.html",
     "URL-ConsultaNFCe": "http://nfceh.sefaz.ce.gov.br/pages/consultaChaveAcesso.jsf",
     "URL-ConsultaNFCe_2.00": "www.sefaz.ce.gov.br/nfce/consulta",


### PR DESCRIPTION
## Parametrização
- UF: CE
- Certificado: A1
- Método: NFCE_Autorizacao
- Status: ✅ Funcionando (com este fix)

## Problema

Na tabela `NFeServicosUrl.json`, a entrada `NFCe_CE_H` tem `URL-QRCode_2.00` apontando pra **Santa Catarina**:

```
"URL-QRCode_2.00": "https://hom.sat.sef.sc.gov.br/nfce/consulta"
```

O QR impresso no DANFCE de homologação do Ceará leva o consumidor pro portal de SC, que não reconhece a chave de acesso. Além disso, `NFCe_CE_P` (produção) não tem a entrada `URL-QRCode_2.00`.

## Fix

- `NFCe_CE_H.URL-QRCode_2.00` → `http://nfceh.sefaz.ce.gov.br/pages/ShowNFCe.html` (URL oficial de homologação da SEFAZ-CE)
- `NFCe_CE_P` ganha `URL-QRCode_2.00` → `http://nfce.sefaz.ce.gov.br/pages/ShowNFCe.html`

Aplicado nas duas cópias do JSON (`src/config` e `src/core/config`).

## Validação

Validado ao vivo em homologação (CE → SVRS, A1, `NFCE_Autorizacao`, cStat 100): com o fix, o QR do cupom resolve corretamente no portal da SEFAZ-CE. Estamos rodando este fix via `pnpm patch` em produção interna há alguns dias.

Obrigado pela lib! 🙌