### PR TITLE
feat(danfe): render infCpl (informações complementares) no cupom NFC-e

### DIFF
--- a/packages/danfe/src/generators/NFCEGerarDanfe.ts
+++ b/packages/danfe/src/generators/NFCEGerarDanfe.ts
@@ -104,7 +104,7 @@ class NFCeGerarDanfe {
             const footerHeight = 170; // Altura do rodapé -> 34.22975675056
 
             // Altura total é a soma das alturas dos itens + cabeçalho + rodapé
-            return headerHeight + footerHeight + (itemsLength * itemHeight) + 5;
+            return headerHeight + footerHeight + (itemsLength * itemHeight) + 5 + (nfeData.infNFe.infAdic?.infCpl ? 14 : 0);
         }
 
         function calculateFontSize(width: number) {
@@ -572,6 +572,11 @@ class NFCeGerarDanfe {
         this.doc.text(`Tributos Totais Incidentes (Lei Federal 12.741/2012): R$ ${parseFloat(String(this.total.ICMSTot.vTotTrib) || '0').toFixed(2)}`, 0, topBeforeQrCode, {
             align: 'center'
         });
+        if (this.infAdic?.infCpl) {
+            this.doc.text(String(this.infAdic.infCpl), 0, topBeforeQrCode + 12, {
+                align: 'center'
+            });
+        }
     }
 
     async generatePDF(exibirMarcaDaguaDanfe?: boolean) {


### PR DESCRIPTION
## Parametrização
- UF: CE
- Certificado: A1
- Método: NFCE_GerarDanfe
- Status: ✅ Funcionando (com este feat)

## Problema

O DANFE A4 (modelo 55) renderiza `infAdic.infCpl`, mas o gerador do CUPOM NFC-e ignora o campo. Uso comum de PDV: imprimir o número do pedido no cupom via `infCpl` (ex.: "Pedido #90106") pro operador casar cupom ↔ pedido — a informação existe no XML autorizado e some na impressão.

## Mudança

- Renderiza `infCpl` centralizado logo abaixo da linha de tributos (Lei 12.741).
- Reserva a altura correspondente no cálculo do tamanho da página — sem isso o cupom (que é cortado no tamanho exato) truncava a última linha.

## Validação

Testado ao vivo gerando PDFs em 58mm e 80mm a partir de procNFe autorizado (CE/SVRS homolog). Rodando via `pnpm patch` em uso interno.

Obrigado pela lib! 🙌