### PR TITLE
NFCe(nfce): documenta fluxo de contingência offline e retransmissão posterior via NFCE_TransmitirContingencia

### DIFF
--- a/examples/NFCe/index.ts
+++ b/examples/NFCe/index.ts
@@ -199,6 +199,25 @@ const testNFCe = async () => {
     };
 
     const retornoNFe = await nfe.NFCE_Autorizacao(autorizacao);
+
+    // Exemplo de contingencia off-line (tpEmis=9): gera e assina, sem transmitir para SEFAZ.
+    const autorizacaoContingencia: NFe = JSON.parse(JSON.stringify(autorizacao));
+    const notaContingencia = Array.isArray(autorizacaoContingencia.NFe)
+        ? autorizacaoContingencia.NFe[0]
+        : autorizacaoContingencia.NFe;
+
+    notaContingencia.infNFe.ide.tpEmis = 9;
+    notaContingencia.infNFe.ide.dhCont = new Date().toISOString();
+    notaContingencia.infNFe.ide.xJust = 'Falha de conectividade com a internet no estabelecimento';
+
+    const retornoContingencia = await nfe.NFCE_Autorizacao(autorizacaoContingencia);
+    const xmlPendente = retornoContingencia?.[0]?.xmlAssinado;
+
+    // Quando a internet voltar, transmita o XML pendente para obter o protocolo real da SEFAZ.
+    if (xmlPendente) {
+        const retornoTransmitirContingencia = await nfe.NFCE_TransmitirContingencia(xmlPendente);
+        console.log('Retorno da retransmissao de contingencia:', retornoTransmitirContingencia);
+    }
 }
 
 await testNFCe();

--- a/packages/nfce/README.md
+++ b/packages/nfce/README.md
@@ -134,6 +134,79 @@ const resultadoCancelamento = await nfceWizard.NFCE_Cancelamento(eventoCancelame
 console.log(resultadoCancelamento);
 ```
 
+## Fluxo de Contingência Offline (tpEmis=9)
+
+No caso de queda de internet ou indisponibilidade técnica, a NFC-e pode ser emitida em contingência off-line com `tpEmis=9`.
+
+O fluxo correto tem 2 etapas:
+
+1. Emissão em contingência:
+- Use `NFCE_Autorizacao` com `tpEmis=9`.
+- A biblioteca gera e assina o XML, mas nao envia para a SEFAZ nesse momento.
+
+2. Transmissão posterior:
+- Quando a conexão voltar, use `NFCE_TransmitirContingencia` com o XML pendente (ou com o mesmo payload em `tpEmis=9`).
+- Nessa etapa ocorre o POST para a SEFAZ e você recebe o protocolo real.
+
+Regras importantes:
+- `tpEmis=9` so e permitido para NFC-e (`mod=65`).
+- Com `tpEmis=4` ou `tpEmis=9`, os campos `dhCont` e `xJust` sao obrigatorios.
+- `xJust` deve ter no minimo 15 caracteres.
+- O prazo de transmissão e ate o final do primeiro dia util subsequente.
+
+### Exemplo de emissão em contingência (etapa 1)
+
+```typescript
+const nfceContingencia: NFe = {
+    ...nfceData,
+    NFe: [
+        {
+            ...nfceData.NFe[0],
+            infNFe: {
+                ...nfceData.NFe[0].infNFe,
+                ide: {
+                    ...nfceData.NFe[0].infNFe.ide,
+                    tpEmis: 9,
+                    dhCont: new Date().toISOString(),
+                    xJust: 'Falha de conectividade com a internet no estabelecimento'
+                }
+            }
+        }
+    ]
+};
+
+const retornoContingencia = await nfceWizard.NFCE_Autorizacao(nfceContingencia);
+const xmlPendente = retornoContingencia?.[0]?.xmlAssinado;
+```
+
+### Exemplo de retransmissão (etapa 2)
+
+```typescript
+if (xmlPendente) {
+    const retornoAutorizacao = await nfceWizard.NFCE_TransmitirContingencia(xmlPendente);
+    console.log(retornoAutorizacao);
+}
+```
+
+### Retorno esperado na etapa offline
+
+Na emissão em contingência (`NFCE_Autorizacao` com `tpEmis=9`), o retorno sinaliza que a nota foi gerada localmente e ainda precisa ser transmitida:
+
+- `cStat = '000'` (codigo interno de contingência da biblioteca)
+- `nProt = 'CONTINGENCIA'`
+- `xmlAssinado` disponivel para armazenamento e transmissão posterior
+
+Se `dfe.armazenarXMLAutorizacao = true`, os XMLs de contingência sao salvos em `dfe.pathXMLAutorizacao`.
+
+### Checklist rapido de teste em homologação
+
+1. Configure ambiente homologação (`tpAmb=2`) e paths de log/XML.
+2. Emita uma NFC-e com `tpEmis=9`, `dhCont` e `xJust` validos.
+3. Confirme retorno com `cStat='000'` e presença de `xmlAssinado`.
+4. Confirme arquivo salvo em `pathXMLAutorizacao` (quando habilitado).
+5. Restabeleça conexão e chame `NFCE_TransmitirContingencia` com o XML pendente.
+6. Confirme retorno com protocolo real da SEFAZ.
+
 ## Documentação
 
 Para a documentação completa acesse [NFeWizard-io - Docs](https://nfewizard-org.github.io/)

--- a/packages/nfce/src/NFCEWizard.ts
+++ b/packages/nfce/src/NFCEWizard.ts
@@ -100,6 +100,34 @@ export class NFCEWizard {
     }
 
     /**
+     * Retransmite uma NFCe emitida em contingência para obtenção de autorização.
+     * Regras: tpEmis permitido apenas 4 (EPEC) ou 9 (Off-line).
+     */
+    async NFCE_TransmitirContingencia(nfce?: any): Promise<any> {
+        try {
+            const nfceAutorizacaoService = new NFCEAutorizacaoService(
+                this.environment,
+                this.utility,
+                this.xmlBuilder,
+                this.axios,
+                this.saveFiles,
+                this.gerarConsulta
+            );
+            const nfceAutorizacao = new NFCEAutorizacao(nfceAutorizacaoService);
+            const response = await nfceAutorizacao.ExecTransmitirContingencia(nfce);
+
+            console.log('Retorno NFCE_TransmitirContingencia');
+            console.table(response.xMotivo);
+            console.log('===================================');
+
+            return response.xmls;
+        } catch (error: any) {
+            logger.error(``, error, { context: 'NFCE_TransmitirContingencia' });
+            throw new Error(`NFCE_TransmitirContingencia: ${error.message}`)
+        }
+    }
+
+    /**
      * Consulta o retorno da autorização de uma NFCe
      * @param recibo - Número do recibo da autorização
      * @returns Resultado da consulta

--- a/packages/nfce/src/operations/NFCEAutorizacao/NFCEAutorizacao.ts
+++ b/packages/nfce/src/operations/NFCEAutorizacao/NFCEAutorizacao.ts
@@ -26,6 +26,13 @@ class NFCEAutorizacao {
         return await this.nfceAutorizacaoService.Exec(data);
     }
 
+    async ExecTransmitirContingencia(data?: any): Promise<any> {
+        if (typeof this.nfceAutorizacaoService.ExecTransmitirContingencia !== 'function') {
+            throw new Error('Método ExecTransmitirContingencia não implementado no serviço de autorização NFCe.');
+        }
+        return await this.nfceAutorizacaoService.ExecTransmitirContingencia(data);
+    }
+
 }
 
 

--- a/packages/nfce/src/operations/NFCEAutorizacao/__tests__/NFCEAutorizacao.test.ts
+++ b/packages/nfce/src/operations/NFCEAutorizacao/__tests__/NFCEAutorizacao.test.ts
@@ -1,0 +1,48 @@
+/*
+ * This file is part of NFeWizard-io.
+ *
+ * NFeWizard-io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NFeWizard-io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NFeWizard-io. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const { NFCEAutorizacao } = require('../NFCEAutorizacao');
+
+describe('NFCEAutorizacao operation', () => {
+    it('deve delegar ExecTransmitirContingencia para o service', async () => {
+        const retornoEsperado = { success: true };
+        const service = {
+            Exec: jest.fn(),
+            ExecTransmitirContingencia: jest.fn().mockResolvedValue(retornoEsperado),
+        };
+
+        const operation = new NFCEAutorizacao(service);
+        const payload = { foo: 'bar' };
+
+        const response = await operation.ExecTransmitirContingencia(payload);
+
+        expect(service.ExecTransmitirContingencia).toHaveBeenCalledWith(payload);
+        expect(response).toBe(retornoEsperado);
+    });
+
+    it('deve lançar erro quando service não implementar ExecTransmitirContingencia', async () => {
+        const service = {
+            Exec: jest.fn(),
+        };
+
+        const operation = new NFCEAutorizacao(service);
+
+        await expect(operation.ExecTransmitirContingencia({})).rejects.toThrow(
+            'Método ExecTransmitirContingencia não implementado no serviço de autorização NFCe.'
+        );
+    });
+});

--- a/packages/nfce/src/services/NFCEAutorizacao/NFCEAutorizacaoService.ts
+++ b/packages/nfce/src/services/NFCEAutorizacao/NFCEAutorizacaoService.ts
@@ -27,6 +27,31 @@ import { Agent } from 'http';
 
 class NFCEAutorizacaoService extends BaseNFE implements NFCEAutorizacaoServiceImpl {
     xmlNFe: string[];
+
+    private converterParaJson(data: NFe | string): NFe {
+        return typeof data === 'string'
+            ? new XmlParser().convertXmlEnvioNFeToJson(data) as NFe
+            : data;
+    }
+
+    private validarTpEmisParaTransmissaoContingencia(dataAsJson: NFe): void {
+        const notas = Array.isArray(dataAsJson.NFe) ? dataAsJson.NFe : [dataAsJson.NFe];
+
+        for (const nota of notas) {
+            const tpEmis = nota.infNFe.ide.tpEmis;
+            if (![4, 9].includes(tpEmis)) {
+                throw new Error(`NFCE_TransmitirContingencia: tpEmis=${tpEmis} inválido. Use apenas tpEmis=4 (EPEC) ou tpEmis=9 (Off-line).`);
+            }
+        }
+    }
+
+    private mapearXmlsComAssinatura(xmls: Array<{ NFe: LayoutNFe; protNFe: ProtNFe }>) {
+        return xmls.map((item, index) => ({
+            ...item,
+            xmlAssinado: this.xmlNFe[index],
+        }));
+    }
+
     constructor(environment: Environment, utility: Utility, xmlBuilder: XmlBuilder, axios: AxiosInstance, saveFiles: SaveFilesImpl, gerarConsulta: GerarConsultaImpl) {
         super(environment, utility, xmlBuilder, 'NFEAutorizacao', axios, saveFiles, gerarConsulta);
         this.xmlNFe = [];
@@ -36,7 +61,7 @@ class NFCEAutorizacaoService extends BaseNFE implements NFCEAutorizacaoServiceIm
         return this.gerarXmlNFCEAutorizacao(data);
     }
 
-    protected salvaArquivos(xmlConsulta: string, responseInJson: GenericObject, xmlRetorno: AxiosResponse<any, any>, options?: Record<string, any>): GenericObject {
+    protected salvaArquivos(_xmlConsulta: string, responseInJson: GenericObject, _xmlRetorno: AxiosResponse<any, any>, options?: Record<string, any>): GenericObject {
 
         // Recupera configuração do ambiente para verificar se os arquivos gerados serão gravados em disco
         const config = this.environment.getConfig();
@@ -65,7 +90,6 @@ class NFCEAutorizacaoService extends BaseNFE implements NFCEAutorizacaoServiceIm
             });
         };
 
-        let chNFe = ''
         let xmlAutorizacaoInJson: GenericObject = {} as GenericObject;
         let xMotivoPorXml: GenericObject[] = [];
         let xmlsInJson: GenericObject[] = [];
@@ -106,7 +130,7 @@ class NFCEAutorizacaoService extends BaseNFE implements NFCEAutorizacaoServiceIm
         }
     }
 
-    private async trataRetorno(xmlRetorno: string, indSinc: number, responseInJson: GenericObject) {
+    private async trataRetorno(xmlRetorno: string, indSinc: number, _responseInJson: GenericObject) {
         try {
             /**
              * Captura o valor nRec e protNFe
@@ -488,26 +512,24 @@ class NFCEAutorizacaoService extends BaseNFE implements NFCEAutorizacaoServiceIm
         return response;
     }
 
-    async Exec(data: NFe | string): Promise<{
+    private async executarAutorizacao(dataAsJson: NFe, transmitirContingencia: boolean): Promise<{
         success: boolean;
         xMotivo: GenericObject;
         xmls: {
             NFe: LayoutNFe;
-            protNFe: ProtNFe
+            protNFe: ProtNFe;
+            xmlAssinado?: string;
         }[];
         emContingencia?: boolean;
     }> {
+        this.xmlNFe = [];
+
         let xmlConsulta: string = '';
         let xmlConsultaSoap: string = '';
-        let webServiceUrlTmp: string = '';
         let responseInJson: GenericObject | undefined = undefined;
         let xmlRetorno: AxiosResponse<any, any> = {} as AxiosResponse<any, any>;
+        let houveTransmissao = false;
         const ContentType = this.setContentType();
-
-        // Se receber XML em string, converte para o JSON do padrão esperado pela lib
-        const dataAsJson: NFe = typeof data === 'string'
-            ? new XmlParser().convertXmlEnvioNFeToJson(data) as NFe
-            : data;
 
         // Verifica se está em contingência (tpEmis = 4 ou 9)
         const nfeData = Array.isArray(dataAsJson.NFe) ? dataAsJson.NFe[0] : dataAsJson.NFe;
@@ -520,7 +542,7 @@ class NFCEAutorizacaoService extends BaseNFE implements NFCEAutorizacaoServiceIm
             // Se está em contingência (tpEmis = 4 ou 9), NÃO transmite para SEFAZ
             // Conforme NT 2018.006: "As NFC-e são geradas, assinadas e os respectivos 
             // DANFE NFC-e são impressos sem a autorização prévia da SEFAZ."
-            if (emContingencia) {
+            if (emContingencia && !transmitirContingencia) {
                 logger.info('NFC-e gerada em CONTINGÊNCIA - Não será transmitida para SEFAZ', {
                     context: 'NFCEAutorizacaoService',
                     tpEmis: nfeData.infNFe.ide.tpEmis,
@@ -538,7 +560,7 @@ class NFCEAutorizacaoService extends BaseNFE implements NFCEAutorizacaoServiceIm
 
                 // Salva os arquivos XML localmente
                 const config = this.environment.getConfig();
-                xmlsGerados.forEach(({ xmlAssinado, NFe }, index) => {
+                xmlsGerados.forEach(({ xmlAssinado }) => {
                     const chaveNFe = this.chaveNfe;
                     
                     if (config.dfe.armazenarXMLAutorizacao) {
@@ -572,6 +594,7 @@ class NFCEAutorizacaoService extends BaseNFE implements NFCEAutorizacaoServiceIm
                     }],
                     xmls: xmlsGerados.map(({ NFe, xmlAssinado }) => ({
                         NFe,
+                        xmlAssinado,
                         protNFe: {
                             $: {
                                 xmlns: 'http://www.portalfiscal.inf.br/nfe',
@@ -595,19 +618,23 @@ class NFCEAutorizacaoService extends BaseNFE implements NFCEAutorizacaoServiceIm
                 };
             }
 
-            // Se NÃO está em contingência (tpEmis = 1), transmite normalmente
+            if (transmitirContingencia && !emContingencia) {
+                throw new Error(`NFCE_TransmitirContingencia: tpEmis=${nfeData.infNFe.ide.tpEmis} inválido. Use apenas tpEmis=4 (EPEC) ou tpEmis=9 (Off-line).`);
+            }
+
+            // Transmite normalmente (tpEmis=1) ou em retransmissão de contingência (tpEmis=4/9)
             const { xmlFormated, agent, webServiceUrl, action } = await this.gerarConsulta.gerarConsulta(xmlConsulta, this.metodo, false, '', 'NFCe');
 
             xmlConsultaSoap = xmlFormated;
-            webServiceUrlTmp = webServiceUrl;
 
             // Efetua requisição para o webservice NFCEAutorizacao
-            const xmlRetorno = await this.callWebService(xmlFormated, webServiceUrl, ContentType, action, agent);
+            xmlRetorno = await this.callWebService(xmlFormated, webServiceUrl, ContentType, action, agent);
+            houveTransmissao = true;
 
             /**
              * Verifica se houve rejeição no processamento do lote
              */
-            const responseInJson = this.utility.verificaRejeicao(xmlRetorno.data, this.metodo);
+            responseInJson = this.utility.verificaRejeicao(xmlRetorno.data, this.metodo);
 
             const retorno = await this.trataRetorno(xmlRetorno.data, dataAsJson.indSinc, responseInJson);
 
@@ -629,20 +656,49 @@ class NFCEAutorizacaoService extends BaseNFE implements NFCEAutorizacaoServiceIm
             return {
                 success: true,
                 xMotivo: xmlFinal.xMotivo,
-                xmls: xmlFinal.response,
+                xmls: this.mapearXmlsComAssinatura(xmlFinal.response),
             }
 
         } finally {
-            // Salva XML de Consulta (apenas se não está em contingência, pois não há comunicação com SEFAZ)
-            if (!emContingencia && xmlConsulta) {
+            // Salva XML de Consulta quando houver transmissão para SEFAZ
+            if (houveTransmissao && xmlConsulta) {
                 this.utility.salvaConsulta(xmlConsulta, xmlConsultaSoap, this.metodo);
             }
 
-            // Salva XML de Retorno (apenas se não está em contingência, pois não há retorno da SEFAZ)
-            if (!emContingencia && xmlRetorno.data) {
+            // Salva XML de Retorno quando houver transmissão para SEFAZ
+            if (houveTransmissao && xmlRetorno.data) {
                 this.utility.salvaRetorno(xmlRetorno.data, responseInJson, this.metodo);
             }
         }
+    }
+
+    async Exec(data: NFe | string): Promise<{
+        success: boolean;
+        xMotivo: GenericObject;
+        xmls: {
+            NFe: LayoutNFe;
+            protNFe: ProtNFe;
+            xmlAssinado?: string;
+        }[];
+        emContingencia?: boolean;
+    }> {
+        const dataAsJson = this.converterParaJson(data);
+        return this.executarAutorizacao(dataAsJson, false);
+    }
+
+    async ExecTransmitirContingencia(data: NFe | string): Promise<{
+        success: boolean;
+        xMotivo: GenericObject;
+        xmls: {
+            NFe: LayoutNFe;
+            protNFe: ProtNFe;
+            xmlAssinado?: string;
+        }[];
+        emContingencia?: boolean;
+    }> {
+        const dataAsJson = this.converterParaJson(data);
+        this.validarTpEmisParaTransmissaoContingencia(dataAsJson);
+        return this.executarAutorizacao(dataAsJson, true);
     }
 
 }

--- a/packages/nfce/src/services/NFCEAutorizacao/NFCEAutorizacaoService.ts.maure.tmp
+++ b/packages/nfce/src/services/NFCEAutorizacao/NFCEAutorizacaoService.ts.maure.tmp
@@ -15,54 +15,28 @@
  * along with NFeWizard-io. If not, see <https://www.gnu.org/licenses/>.
  */
 import { AxiosInstance, AxiosResponse } from 'axios';
-import { NFERetornoAutorizacao } from '../../operations/NFERetornoAutorizacao/NFERetornoAutorizacao.js';
-import { XmlParser, Environment, Utility, XmlBuilder, ValidaCPFCNPJ, BaseNFE, mountCOFINS, mountICMS, mountPIS } from '@nfewizard/shared';
+import { XmlParser, Environment, Utility, XmlBuilder, ValidaCPFCNPJ, BaseNFE, mountCOFINS, mountICMS, mountPIS, logger } from '@nfewizard/shared';
 import { GenericObject, LayoutNFe, NFe, ProtNFe } from '@nfewizard/types/nfe';
+import { GerarConsultaImpl, NFCEAutorizacaoServiceImpl, SaveFilesImpl } from '@nfewizard/types/shared';
 import { format } from 'date-fns';
-import { GerarConsultaImpl, NFEAutorizacaoServiceImpl, SaveFilesImpl } from '@nfewizard/types/shared';
-import { NFERetornoAutorizacaoService } from '../NFERetornoAutorizacao/NFERetornoAutorizacaoService.js';
-import { logger } from '@nfewizard/shared';
+import { generateQRCodeURLOffline, generateQRCodeURLOnline } from './util/NFCEQRCode.js';
+import xml2js, { Builder } from 'xml2js';
+import { NFCERetornoAutorizacaoService } from '../NFCERetornoAutorizacao/NFCERetornoAutorizacaoService.js';
+import { NFCERetornoAutorizacao } from '../../operations/NFCERetornoAutorizacao/NFCERetornoAutorizacao.js';
 import { Agent } from 'http';
 
-const T_MED = 5; // Tempo médio de resposta padrão em segundos
-
-export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServiceImpl {
+class NFCEAutorizacaoService extends BaseNFE implements NFCEAutorizacaoServiceImpl {
     xmlNFe: string[];
-
-    private converterParaJson(data: NFe | string): NFe {
-        return typeof data === 'string'
-            ? new XmlParser().convertXmlEnvioNFeToJson(data) as NFe
-            : data;
-    }
-
-    private validarTpEmisParaTransmissaoContingencia(dataAsJson: NFe): void {
-        const notas = Array.isArray(dataAsJson.NFe) ? dataAsJson.NFe : [dataAsJson.NFe];
-
-        for (const nota of notas) {
-            const tpEmis = nota.infNFe.ide.tpEmis;
-            if (![4, 5].includes(tpEmis)) {
-                throw new Error(`NFE_TransmitirContingencia: tpEmis=${tpEmis} inválido. Use apenas tpEmis=4 (EPEC) ou tpEmis=5 (FS-DA).`);
-            }
-        }
-    }
-
-    private mapearXmlsComAssinatura(xmls: Array<{ NFe: LayoutNFe; protNFe: ProtNFe }>) {
-        return xmls.map((item, index) => ({
-            ...item,
-            xmlAssinado: this.xmlNFe[index],
-        }));
-    }
-
     constructor(environment: Environment, utility: Utility, xmlBuilder: XmlBuilder, axios: AxiosInstance, saveFiles: SaveFilesImpl, gerarConsulta: GerarConsultaImpl) {
         super(environment, utility, xmlBuilder, 'NFEAutorizacao', axios, saveFiles, gerarConsulta);
         this.xmlNFe = [];
     }
 
     protected gerarXml(data: NFe): string {
-        return this.gerarXmlNFeAutorizacao(data);
+        return this.gerarXmlNFCEAutorizacao(data);
     }
 
-    protected salvaArquivos(_xmlConsulta: string, responseInJson: GenericObject, _xmlRetorno: AxiosResponse<any, any>, options?: Record<string, any>): GenericObject {
+    protected salvaArquivos(xmlConsulta: string, responseInJson: GenericObject, xmlRetorno: AxiosResponse<any, any>, options?: Record<string, any>): GenericObject {
 
         // Recupera configuração do ambiente para verificar se os arquivos gerados serão gravados em disco
         const config = this.environment.getConfig();
@@ -91,6 +65,7 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
             });
         };
 
+        let chNFe = ''
         let xmlAutorizacaoInJson: GenericObject = {} as GenericObject;
         let xMotivoPorXml: GenericObject[] = [];
         let xmlsInJson: GenericObject[] = [];
@@ -100,7 +75,7 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
             const json = new XmlParser();
 
             for (let i = 0; i < xmlAutorizacao.length; i++) {
-                xmlAutorizacaoInJson = json.convertXmlToJson(xmlAutorizacao[i], 'NFEAutorizacaoFinal');
+                xmlAutorizacaoInJson = json.convertXmlToJson(xmlAutorizacao[i], 'NFCEAutorizacaoFinal');
                 xmlsInJson.push(xmlAutorizacaoInJson);
 
                 const chNFe = xmlAutorizacaoInJson.protNFe.infProt.chNFe;
@@ -132,37 +107,34 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
     }
 
     private async trataRetorno(xmlRetorno: string, indSinc: number, responseInJson: GenericObject) {
-        /**
-         * Captura o valor nRec e protNFe
-         */
-        const { nRec, protNFe } = this.utility.getProtNFe(xmlRetorno);
+        try {
+            /**
+             * Captura o valor nRec e protNFe
+             */
+            const { nRec, protNFe } = this.utility.getProtNFe(xmlRetorno);
 
-        /**
-         * 0 - assíncrona
-         * 1 - síncrona
-         */
-        let tipoEmissao = 0;
-        if (indSinc === 1 && protNFe) {
-            tipoEmissao = 1;
+            /**
+             * 0 - assíncrona
+             * 1 - síncrona
+             */
+            let tipoEmissao = 0;
+            if (indSinc === 1 && protNFe) {
+                tipoEmissao = 1;
+            }
+            const nfeRetornoAutService = new NFCERetornoAutorizacaoService(this.environment, this.utility, this.xmlBuilder, this.axios, this.saveFiles, this.gerarConsulta);
+            const nfeRetornoAut = new NFCERetornoAutorizacao(nfeRetornoAutService);
+
+            const retorno = await nfeRetornoAut.getXmlRetorno({
+                tipoEmissao,
+                nRec,
+                protNFe,
+                xmlNFe: this.xmlNFe
+            });
+
+            return retorno;
+        } catch (error: any) {
+            throw new Error(error.message)
         }
-
-        const nfeRetornoAutService = new NFERetornoAutorizacaoService(this.environment, this.utility, this.xmlBuilder, this.axios, this.saveFiles, this.gerarConsulta);
-        const nfeRetornoAut = new NFERetornoAutorizacao(nfeRetornoAutService);
-
-        /**
-         * Aguarda o Tempo médio de resposta do serviço (em segundos) dos últimos 5 minutos
-         * A informação do tMed só é recebida caso o processamento for assíncrono (indSinc = 0)
-         */
-        if (tipoEmissao !== 1) await new Promise(resolve => setTimeout(resolve, Number(responseInJson.infRec?.tMed || T_MED) * 1000));
-
-        const retorno = await nfeRetornoAut.getXmlRetorno({
-            tipoEmissao,
-            nRec,
-            protNFe,
-            xmlNFe: this.xmlNFe
-        });
-
-        return retorno;
     }
 
     /**
@@ -182,10 +154,16 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
         return ano + mes;
     }
 
-    // private _gerarCodigoNumerico() {
-    //     // Lógica para gerar um código numérico aleatório de 8 dígitos
-    //     return Math.floor(Math.random() * 100000000).toString().padStart(8, '0');
-    // }
+    private diaEmissao(dhEmi: string) {
+        // Converte a string para uma data
+        const dataAtual = new Date(dhEmi);
+
+        // Extrai o dia com dois dígitos
+        const dia = dataAtual.getDate().toString().padStart(2, '0');
+
+        // Retorna o dia
+        return dia;
+    }
 
     private calcularModulo11(sequencia: string) {
         const pesos = [4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
@@ -209,7 +187,7 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
                 ide: { cUF, mod, serie, nNF, tpEmis, cNF, dhEmi },
                 emit: { CNPJCPF },
             },
-        } = data
+        } = data;
 
         if (Id) {
             this.chaveNfe = Id
@@ -241,7 +219,7 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
         // Valida se CPF ou CNPJ
         const nfeAutorizacaoHandler = new ValidaCPFCNPJ();
         const { documentoValido, tipoDoDocumento } = nfeAutorizacaoHandler.validarCpfCnpj(doc);
-        console.log({ documentoValido, tipoDoDocumento })
+
         if (!documentoValido || tipoDoDocumento === 'Desconhecido') {
             const message = tipoDoDocumento === 'Desconhecido'
                 ? `Documento do ${campo} ausente ou inválido`
@@ -252,16 +230,42 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
         return tipoDoDocumento;
     }
 
-    private gerarXmlNFeAutorizacao(data: NFe) {
+    private extrairDigestValue(xmlAssinado: string): string {
+        const match = xmlAssinado.match(/<DigestValue>([^<]+)<\/DigestValue>/);
+        if (match && match[1]) {
+            return match[1];
+        }
+        throw new Error('DigestValue não encontrado no XML assinado.');
+    }
+
+    private gerarXmlNFCEAutorizacao(data: NFe) {
         logger.info('Montando estrutuda do XML em JSON', {
-            context: 'NFEAutorizacaoService',
+            context: 'NFCEAutorizacaoService',
         });
         const createXML = (NFe: LayoutNFe) => {
+            // Validações de contingência conforme NT 2018.006
+            const { tpEmis, mod, dhCont, xJust } = NFe.infNFe.ide;
+
+            // Validação 1: Contingência off-line (tpEmis=9) só é permitida para NFC-e (mod=65)
+            if (tpEmis === 9 && mod !== 65) {
+                throw new Error('Contingência off-line (tpEmis=9) só é permitida para NFC-e (mod=65)');
+            }
+
+            // Validação 2: Campos dhCont e xJust são obrigatórios quando tpEmis = 4 ou 9
+            if ([4, 9].includes(tpEmis)) {
+                if (!dhCont || dhCont.trim() === '') {
+                    throw new Error(`Campo dhCont (Data e Hora de entrada em contingência) é obrigatório quando tpEmis=${tpEmis}`);
+                }
+                if (!xJust || xJust.trim() === '' || xJust.length < 15) {
+                    throw new Error(`Campo xJust (Justificativa da entrada em contingência) é obrigatório e deve ter no mínimo 15 caracteres quando tpEmis=${tpEmis}`);
+                }
+            }
+
             // Verificando se existe mais de um produto
             if (NFe?.infNFe?.det instanceof Array) {
                 // Adicionando indice ao item
                 const formatedItens = NFe.infNFe.det.map((det, index) => {
-                    if (det.imposto?.ICMS?.dadosICMS) {
+                    if (det.imposto.ICMS?.dadosICMS) {
                         const icms = mountICMS(det.imposto.ICMS.dadosICMS);
                         det.imposto.ICMS = icms;
                     }
@@ -284,11 +288,9 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
             }
 
             // Cria chave da nota e grava digito verificador
-            const { chaveAcesso, dv } = this.calcularDigitoVerificador(NFe);
-
+            const { chaveAcesso, dv } = this.calcularDigitoVerificador(NFe)
             NFe.infNFe.ide.cDV = dv;
             NFe.infNFe.ide.verProc = NFe.infNFe.ide.verProc || '1.0.0.0';
-            delete NFe.infNFe.Id
 
             // Gera hashCSRT automaticamente se infRespTec e idCSRT existirem
             if (NFe.infNFe.infRespTec?.idCSRT) {
@@ -303,12 +305,24 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
             // Valida Documento do emitente
             NFe.infNFe.emit = Object.assign({ [this.validaDocumento(String(NFe.infNFe.emit.CNPJCPF), 'emitente')]: NFe.infNFe.emit.CNPJCPF }, NFe.infNFe.emit)
             delete NFe.infNFe.emit.CNPJCPF;
-
             // Valida Documento do destinatário
+
             if (NFe.infNFe.dest) {
-                NFe.infNFe.dest = Object.assign({ [this.validaDocumento(String(NFe.infNFe.dest?.CNPJCPF || ''), 'destinatário')]: NFe.infNFe.dest?.CNPJCPF || '' }, NFe.infNFe.dest)
-                delete NFe.infNFe.dest.CNPJCPF;
+                const tipoDocDest = this.validaDocumento(String(NFe.infNFe.dest?.CNPJCPF || ''), 'destinatário');
+                const cnpjcpfValue = NFe.infNFe.dest?.CNPJCPF || '';
+                const xNomeValue = NFe.infNFe.ide.tpAmb === 2 
+                    ? 'NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL'
+                    : NFe.infNFe.dest.xNome;
+                
+                // Reconstrói o objeto dest mantendo a ordem correta
+                const { CNPJCPF, xNome, ...restoDest } = NFe.infNFe.dest;
+                NFe.infNFe.dest = {
+                    [tipoDocDest]: cnpjcpfValue,
+                    ...(xNomeValue && { xNome: xNomeValue }),
+                    ...restoDest
+                };
             }
+
             // Valida Documento do transportador
             if (NFe.infNFe.transp.transporta) {
                 NFe.infNFe.transp.transporta = Object.assign({ [this.validaDocumento(String(NFe.infNFe.transp.transporta?.CNPJCPF), 'transportador')]: NFe.infNFe.transp.transporta?.CNPJCPF }, NFe.infNFe.transp.transporta)
@@ -339,12 +353,23 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
                 }
             }
 
-            // Caso Seja hambiente de homologação
-            if (NFe.infNFe.dest) {
-                if (NFe.infNFe.ide.tpAmb === 2) {
-                    NFe.infNFe.dest.xNome = 'NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
+            const { nfe: { idCSC, tokenCSC } } = this.environment.getConfig();
+
+            let qrCode = '';
+            if (![4, 9].includes(NFe.infNFe.ide.tpEmis)) {
+                qrCode = generateQRCodeURLOnline(chaveAcesso, '2', NFe.infNFe.ide.tpAmb, Number(idCSC), String(tokenCSC), this.utility);
+            }
+
+            const urlConsultaNFCe = this.utility.getUrlNFCe('URL-ConsultaNFCe', false, '');
+
+            const nfeWithQrCode = {
+                ...NFe,
+                infNFeSupl: {
+                    qrCode: qrCode,
+                    urlChave: urlConsultaNFCe,
                 }
             }
+            NFe = nfeWithQrCode;
 
             const xmlObject = {
                 $: {
@@ -356,11 +381,48 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
                         Id: chaveAcesso,
                     },
                     ...NFe.infNFe
+                },
+                infNFeSupl: {
+                    ...NFe.infNFeSupl
                 }
             }
 
             const eventoXML = this.xmlBuilder.gerarXml(xmlObject, 'NFe', this.metodo)
-            const xmlAssinado = this.xmlBuilder.assinarXML(eventoXML, 'infNFe')
+            let xmlAssinado = this.xmlBuilder.assinarXML(eventoXML, 'infNFe')
+
+            if ([4, 9].includes(NFe.infNFe.ide.tpEmis)) {
+                // capturar digestValue
+                const digestValue = this.extrairDigestValue(xmlAssinado);
+
+                // substituir tag qrcode
+                const tpAmb = NFe.infNFe.ide.tpAmb;
+                const valNF = NFe.infNFe.total.ICMSTot.vNF;
+
+                const diaEmissao = this.diaEmissao(NFe.infNFe.ide.dhEmi);
+                qrCode = generateQRCodeURLOffline(chaveAcesso, '2', tpAmb, diaEmissao, valNF, digestValue, Number(idCSC), String(tokenCSC), this.utility);
+
+                xml2js.parseString(xmlAssinado, (err, result) => {
+                    if (err) {
+                        throw new Error('Erro ao parsear o XML para atualização do qrCode:');
+                    } else {
+                        if (result.NFe?.infNFeSupl[0]?.qrCode) {
+                            result.NFe.infNFeSupl[0].qrCode[0] = qrCode;
+
+                            const builder = new Builder({
+                                headless: true, renderOpts: {
+                                    pretty: false
+                                },
+                            });
+                            xmlAssinado = builder.buildObject(result)
+                        } else {
+                            throw new Error('Tag qrCode não encontrada no XML.');
+                        }
+                    }
+                });
+
+
+            }
+
             this.xmlNFe.push(xmlAssinado);
         }
 
@@ -393,12 +455,16 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
     protected async callWebService(xmlConsulta: string, webServiceUrl: string, ContentType: string, action: string, agent: Agent): Promise<AxiosResponse<any, any>> {
         const startTime = Date.now();
 
+        const { nfe: { tokenCSC } } = this.environment.getConfig();
+
         const headers = {
             'Content-Type': ContentType,
-        };
+            'SOAPAction': action,
+            'CSC': tokenCSC,
+        }
 
         logger.http('Iniciando comunicação com o webservice', {
-            context: `NFEAutorizacaoService`,
+            context: `NFCEAutorizacaoService`,
             method: this.metodo,
             url: webServiceUrl,
             action,
@@ -413,7 +479,7 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
         const duration = Date.now() - startTime;
 
         logger.http('Comunicação concluída com sucesso', {
-            context: `NFEAutorizacaoService`,
+            context: `NFCEAutorizacaoService`,
             method: this.metodo,
             duration: `${duration}ms`,
             responseSize: response.data ? JSON.stringify(response.data).length : 0
@@ -422,38 +488,126 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
         return response;
     }
 
-    private async executarAutorizacao(dataAsJson: NFe): Promise<{
+    async Exec(data: NFe | string): Promise<{
         success: boolean;
         xMotivo: GenericObject;
         xmls: {
             NFe: LayoutNFe;
-            protNFe: ProtNFe;
-            xmlAssinado?: string;
+            protNFe: ProtNFe
         }[];
+        emContingencia?: boolean;
     }> {
-        this.xmlNFe = [];
-
         let xmlConsulta: string = '';
         let xmlConsultaSoap: string = '';
+        let webServiceUrlTmp: string = '';
         let responseInJson: GenericObject | undefined = undefined;
         let xmlRetorno: AxiosResponse<any, any> = {} as AxiosResponse<any, any>;
         const ContentType = this.setContentType();
 
-        try {
-            // Gerando XML para consulta de Status do Serviço
-            xmlConsulta = this.gerarXmlNFeAutorizacao(dataAsJson);
+        // Se receber XML em string, converte para o JSON do padrão esperado pela lib
+        const dataAsJson: NFe = typeof data === 'string'
+            ? new XmlParser().convertXmlEnvioNFeToJson(data) as NFe
+            : data;
 
-            const { xmlFormated, agent, webServiceUrl, action } = await this.gerarConsulta.gerarConsulta(xmlConsulta, this.metodo);
+        // Verifica se está em contingência (tpEmis = 4 ou 9)
+        const nfeData = Array.isArray(dataAsJson.NFe) ? dataAsJson.NFe[0] : dataAsJson.NFe;
+        const emContingencia = [4, 9].includes(nfeData.infNFe.ide.tpEmis);
+        
+        try {
+            // Gerando XML da NFC-e
+            xmlConsulta = this.gerarXmlNFCEAutorizacao(dataAsJson);
+
+            // Se está em contingência (tpEmis = 4 ou 9), NÃO transmite para SEFAZ
+            // Conforme NT 2018.006: "As NFC-e são geradas, assinadas e os respectivos 
+            // DANFE NFC-e são impressos sem a autorização prévia da SEFAZ."
+            if (emContingencia) {
+                logger.info('NFC-e gerada em CONTINGÊNCIA - Não será transmitida para SEFAZ', {
+                    context: 'NFCEAutorizacaoService',
+                    tpEmis: nfeData.infNFe.ide.tpEmis,
+                    nNF: nfeData.infNFe.ide.nNF,
+                });
+
+                // Extrai os XMLs das NFCe geradas (já assinados)
+                const xmlsGerados = this.xmlNFe.map((xmlAssinado, index) => {
+                    const nfeItem = Array.isArray(dataAsJson.NFe) ? dataAsJson.NFe[index] : dataAsJson.NFe;
+                    return {
+                        NFe: nfeItem,
+                        xmlAssinado: xmlAssinado,
+                    };
+                });
+
+                // Salva os arquivos XML localmente
+                const config = this.environment.getConfig();
+                xmlsGerados.forEach(({ xmlAssinado, NFe }, index) => {
+                    const chaveNFe = this.chaveNfe;
+                    
+                    if (config.dfe.armazenarXMLAutorizacao) {
+                        const fileName = `NFCe-Contingencia-${chaveNFe}`;
+                        this.utility.salvaXML({
+                            data: xmlAssinado,
+                            fileName,
+                            metodo: this.metodo,
+                            path: config.dfe.pathXMLAutorizacao,
+                        });
+
+                        logger.info('XML de contingência salvo localmente', {
+                            context: 'NFCEAutorizacaoService',
+                            fileName: `${fileName}.xml`,
+                            path: config.dfe.pathXMLAutorizacao,
+                        });
+                    }
+                });
+
+                const mensagemContingencia = nfeData.infNFe.ide.tpEmis === 4 
+                    ? 'NFC-e gerada em Contingência EPEC (tpEmis=4)'
+                    : 'NFC-e gerada em Contingência Off-line (tpEmis=9)';
+
+                return {
+                    success: true,
+                    emContingencia: true,
+                    xMotivo: [{
+                        chNFe: this.chaveNfe,
+                        xMotivo: mensagemContingencia + '. Transmita para autorização quando o problema técnico for resolvido (prazo: até o final do primeiro dia útil subsequente).',
+                        cStat: '000', // Código customizado para contingência
+                    }],
+                    xmls: xmlsGerados.map(({ NFe, xmlAssinado }) => ({
+                        NFe,
+                        protNFe: {
+                            $: {
+                                xmlns: 'http://www.portalfiscal.inf.br/nfe',
+                                versao: '4.00',
+                            },
+                            infProt: {
+                                $: {
+                                    Id: 'IDCONTINGENCIA',
+                                },
+                                tpAmb: NFe.infNFe.ide.tpAmb,
+                                verAplic: 'contingencia',
+                                chNFe: this.chaveNfe,
+                                dhRecbto: new Date().toISOString(),
+                                nProt: 'CONTINGENCIA',
+                                digVal: '',
+                                cStat: '000',
+                                xMotivo: mensagemContingencia,
+                            }
+                        } as ProtNFe
+                    })),
+                };
+            }
+
+            // Se NÃO está em contingência (tpEmis = 1), transmite normalmente
+            const { xmlFormated, agent, webServiceUrl, action } = await this.gerarConsulta.gerarConsulta(xmlConsulta, this.metodo, false, '', 'NFCe');
 
             xmlConsultaSoap = xmlFormated;
+            webServiceUrlTmp = webServiceUrl;
 
-            // Efetua requisição para o webservice NFEStatusServico
-            xmlRetorno = await this.callWebService(xmlFormated, webServiceUrl, ContentType, action, agent);
+            // Efetua requisição para o webservice NFCEAutorizacao
+            const xmlRetorno = await this.callWebService(xmlFormated, webServiceUrl, ContentType, action, agent);
 
             /**
              * Verifica se houve rejeição no processamento do lote
              */
-            responseInJson = this.utility.verificaRejeicao(xmlRetorno.data, this.metodo);
+            const responseInJson = this.utility.verificaRejeicao(xmlRetorno.data, this.metodo);
 
             const retorno = await this.trataRetorno(xmlRetorno.data, dataAsJson.indSinc, responseInJson);
 
@@ -461,53 +615,36 @@ export class NFEAutorizacaoService extends BaseNFE implements NFEAutorizacaoServ
                 {
                     xmlAutorizacao: retorno.data,
                     xMotivo: retorno.message
-                });
+                })
 
-            logger.info('NFe transmitida com sucesso', {
-                context: 'NFEAutorizacaoService',
+            xmlFinal.xMotivo = xmlFinal.xMotivo.map((item: any) => ({
+                ...item,
+                xMotivo: item.xMotivo.replace('NF-e', 'NFC-e')
+            }));
+
+            logger.info('NFCe transmitida com sucesso', {
+                context: 'NFCEAutorizacaoService',
             });
 
             return {
                 success: true,
                 xMotivo: xmlFinal.xMotivo,
-                xmls: this.mapearXmlsComAssinatura(xmlFinal.response),
-            };
+                xmls: xmlFinal.response,
+            }
 
         } finally {
-            // Salva XML de Consulta
-            this.utility.salvaConsulta(xmlConsulta, xmlConsultaSoap, this.metodo);
+            // Salva XML de Consulta (apenas se não está em contingência, pois não há comunicação com SEFAZ)
+            if (!emContingencia && xmlConsulta) {
+                this.utility.salvaConsulta(xmlConsulta, xmlConsultaSoap, this.metodo);
+            }
 
-            // Salva XML de Retorno
-            this.utility.salvaRetorno(xmlRetorno.data, responseInJson, this.metodo);
+            // Salva XML de Retorno (apenas se não está em contingência, pois não há retorno da SEFAZ)
+            if (!emContingencia && xmlRetorno.data) {
+                this.utility.salvaRetorno(xmlRetorno.data, responseInJson, this.metodo);
+            }
         }
     }
 
-    public async Exec(data: NFe | string): Promise<{
-        success: boolean;
-        xMotivo: GenericObject;
-        xmls: {
-            NFe: LayoutNFe;
-            protNFe: ProtNFe;
-            xmlAssinado?: string;
-        }[];
-    }> {
-        const dataAsJson = this.converterParaJson(data);
-        return this.executarAutorizacao(dataAsJson);
-    }
-
-    public async ExecTransmitirContingencia(data: NFe | string): Promise<{
-        success: boolean;
-        xMotivo: GenericObject;
-        xmls: {
-            NFe: LayoutNFe;
-            protNFe: ProtNFe;
-            xmlAssinado?: string;
-        }[];
-    }> {
-        const dataAsJson = this.converterParaJson(data);
-        this.validarTpEmisParaTransmissaoContingencia(dataAsJson);
-        return this.executarAutorizacao(dataAsJson);
-    }
 }
 
-export default NFEAutorizacaoService;
+export { NFCEAutorizacaoService };

--- a/packages/nfewizard-io/src/NFeWizard.ts
+++ b/packages/nfewizard-io/src/NFeWizard.ts
@@ -193,6 +193,14 @@ export class NFeWizard implements NFeWizardImpl {
     }
 
     /**
+     * Retransmite uma NFe emitida em contingência para obtenção de autorização.
+     * Aceita apenas tpEmis 4 (EPEC) e 5 (FS-DA).
+     */
+    async NFE_TransmitirContingencia(data: NFe | string) {
+        return await this.nfeWizardService.NFE_TransmitirContingencia(data);
+    }
+
+    /**
      * Valida um XML contra o schema XSD do método fiscal informado.
      * O `environment` é injetado automaticamente a partir da configuração da lib.
      *

--- a/packages/nfewizard-io/src/nfe/operations/NFEAutorizacao/NFEAutorizacao.ts
+++ b/packages/nfewizard-io/src/nfe/operations/NFEAutorizacao/NFEAutorizacao.ts
@@ -26,6 +26,13 @@ export class NFEAutorizacao {
         return await this.nfeAutorizacaoService.Exec(data);
     }
 
+    async ExecTransmitirContingencia(data?: any): Promise<any> {
+        if (typeof this.nfeAutorizacaoService.ExecTransmitirContingencia !== 'function') {
+            throw new Error('Método ExecTransmitirContingencia não implementado no serviço de autorização NFe.');
+        }
+        return await this.nfeAutorizacaoService.ExecTransmitirContingencia(data);
+    }
+
 }
 
 export default NFEAutorizacao;

--- a/packages/nfewizard-io/src/nfe/operations/NFEAutorizacao/__tests__/NFEAutorizacao.test.ts
+++ b/packages/nfewizard-io/src/nfe/operations/NFEAutorizacao/__tests__/NFEAutorizacao.test.ts
@@ -1,0 +1,48 @@
+/*
+ * This file is part of NFeWizard-io.
+ *
+ * NFeWizard-io is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NFeWizard-io is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with NFeWizard-io. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const NFEAutorizacao = require('../NFEAutorizacao').default;
+
+describe('NFEAutorizacao operation', () => {
+    it('deve delegar ExecTransmitirContingencia para o service', async () => {
+        const retornoEsperado = { success: true };
+        const service = {
+            Exec: jest.fn(),
+            ExecTransmitirContingencia: jest.fn().mockResolvedValue(retornoEsperado),
+        };
+
+        const operation = new NFEAutorizacao(service);
+        const payload = { foo: 'bar' };
+
+        const response = await operation.ExecTransmitirContingencia(payload);
+
+        expect(service.ExecTransmitirContingencia).toHaveBeenCalledWith(payload);
+        expect(response).toBe(retornoEsperado);
+    });
+
+    it('deve lançar erro quando service não implementar ExecTransmitirContingencia', async () => {
+        const service = {
+            Exec: jest.fn(),
+        };
+
+        const operation = new NFEAutorizacao(service);
+
+        await expect(operation.ExecTransmitirContingencia({})).rejects.toThrow(
+            'Método ExecTransmitirContingencia não implementado no serviço de autorização NFe.'
+        );
+    });
+});

--- a/packages/nfewizard-io/src/nfe/services/NFeWizard/NFeWizardService.ts
+++ b/packages/nfewizard-io/src/nfe/services/NFeWizard/NFeWizardService.ts
@@ -396,6 +396,27 @@ class NFeWizardService implements NFeWizardServiceImpl {
     }
 
     /**
+     * Retransmite uma NFe emitida em contingência para obter autorização.
+     * Regras: tpEmis permitido apenas 4 (EPEC) ou 5 (FS-DA).
+     */
+    async NFE_TransmitirContingencia(data: NFe | string) {
+        try {
+            const autorizacaoService = new NFEAutorizacaoService(this.environment, this.utility, this.xmlBuilder, this.axios, this.saveFiles, this.gerarConsulta);
+            const autorizacao = new NFEAutorizacao(autorizacaoService);
+            const response = await autorizacao.ExecTransmitirContingencia(data);
+
+            console.log('Retorno NFE_TransmitirContingencia');
+            console.table(response.xMotivo);
+            console.log('===================================');
+
+            return response.xmls
+        } catch (error: any) {
+            logger.error(``, error, { context: 'NFE_TransmitirContingencia', });
+            throw new Error(`NFE_TransmitirContingencia: ${error.message}`)
+        }
+    }
+
+    /**
      * Inutilização
      */
     async NFE_Inutilizacao(data: InutilizacaoData) {

--- a/packages/types/src/nfe/NFEAutorizacaoServiceImpl.d.ts
+++ b/packages/types/src/nfe/NFEAutorizacaoServiceImpl.d.ts
@@ -1,12 +1,22 @@
 import { GenericObject } from '../shared/Utils.js';
 import { LayoutNFe, NFe, ProtNFe } from './index.js';
 export interface NFEAutorizacaoServiceImpl {
-    Exec(data: NFe): Promise<{
+    Exec(data: NFe | string): Promise<{
         success: boolean;
         xMotivo: GenericObject;
         xmls: {
             NFe: LayoutNFe;
             protNFe: ProtNFe;
+            xmlAssinado?: string;
+        }[];
+    }>;
+    ExecTransmitirContingencia?(data: NFe | string): Promise<{
+        success: boolean;
+        xMotivo: GenericObject;
+        xmls: {
+            NFe: LayoutNFe;
+            protNFe: ProtNFe;
+            xmlAssinado?: string;
         }[];
     }>;
 }

--- a/packages/types/src/shared/NFeWizardImpl.d.ts
+++ b/packages/types/src/shared/NFeWizardImpl.d.ts
@@ -18,9 +18,15 @@ export interface NFeWizardImpl {
     NFE_DistribuicaoDFePorUltNSU(data: DFePorUltimoNSU): Promise<GenericObject>;
     NFE_DistribuicaoDFePorNSU(data: DFePorNSU): Promise<GenericObject>;
     NFE_DistribuicaoDFePorChave(data: DFePorChaveNFe): Promise<GenericObject>;
-    NFE_Autorizacao(data: NFe): Promise<{
+    NFE_Autorizacao(data: NFe | string): Promise<{
         NFe: LayoutNFe;
         protNFe: ProtNFe;
+        xmlAssinado?: string;
+    }[]>;
+    NFE_TransmitirContingencia(data: NFe | string): Promise<{
+        NFe: LayoutNFe;
+        protNFe: ProtNFe;
+        xmlAssinado?: string;
     }[]>;
     NFe: LayoutNFe;
     protNFe: ProtNFe;

--- a/packages/types/src/shared/NFeWizardImpl.ts
+++ b/packages/types/src/shared/NFeWizardImpl.ts
@@ -95,7 +95,8 @@ export interface NFeWizardImpl {
     NFE_DistribuicaoDFePorUltNSU(data: DFePorUltimoNSU): Promise<GenericObject>;
     NFE_DistribuicaoDFePorNSU(data: DFePorNSU): Promise<GenericObject>;
     NFE_DistribuicaoDFePorChave(data: DFePorChaveNFe): Promise<GenericObject>;
-    NFE_Autorizacao(data: NFe): Promise<{ NFe: LayoutNFe, protNFe: ProtNFe }[]>;
+    NFE_Autorizacao(data: NFe | string): Promise<{ NFe: LayoutNFe, protNFe: ProtNFe, xmlAssinado?: string }[]>;
+    NFE_TransmitirContingencia(data: NFe | string): Promise<{ NFe: LayoutNFe, protNFe: ProtNFe, xmlAssinado?: string }[]>;
     NFE_Inutilizacao(data: InutilizacaoData): Promise<any>;
     NFE_EnviaEmail(mailParams: EmailParams): any;
     NFE_SchemaValidate(xml: string, metodo: SchemaValidateMethod, validator?: 'validateSchemaJsBased' | 'validateSchemaJavaBased'): Promise<SchemaValidationResult>;

--- a/packages/types/src/shared/NFeWizardServiceImpl.d.ts
+++ b/packages/types/src/shared/NFeWizardServiceImpl.d.ts
@@ -19,9 +19,15 @@ export interface NFeWizardServiceImpl {
     NFE_DistribuicaoDFePorUltNSU(data: DFePorUltimoNSU): Promise<GenericObject>;
     NFE_DistribuicaoDFePorNSU(data: DFePorNSU): Promise<GenericObject>;
     NFE_DistribuicaoDFePorChave(data: DFePorChaveNFe): Promise<GenericObject>;
-    NFE_Autorizacao(data: NFe): Promise<{
+    NFE_Autorizacao(data: NFe | string): Promise<{
         NFe: LayoutNFe;
         protNFe: ProtNFe;
+        xmlAssinado?: string;
+    }[]>;
+    NFE_TransmitirContingencia(data: NFe | string): Promise<{
+        NFe: LayoutNFe;
+        protNFe: ProtNFe;
+        xmlAssinado?: string;
     }[]>;
     NFE_SchemaValidate(xml: string, metodo: SchemaValidateMethod, validator?: 'validateSchemaJsBased' | 'validateSchemaJavaBased'): Promise<SchemaValidationResult>;
     NFe: LayoutNFe;

--- a/packages/types/src/shared/index.d.ts
+++ b/packages/types/src/shared/index.d.ts
@@ -14,6 +14,7 @@ export interface NFeWizardServiceImpl {
 }
 export interface NFEAutorizacaoServiceImpl {
     Exec(...args: any[]): Promise<any>;
+    ExecTransmitirContingencia?(...args: any[]): Promise<any>;
 }
 export interface NFEconsultaProtocoloServiceImpl {
     Exec(...args: any[]): Promise<any>;
@@ -35,6 +36,7 @@ export interface NFEStatusServicoServiceImpl {
 }
 export interface NFCEAutorizacaoServiceImpl {
     Exec(...args: any[]): Promise<any>;
+    ExecTransmitirContingencia?(...args: any[]): Promise<any>;
 }
 export interface NFCERetornoAutorizacaoServiceImpl {
     getXmlRetorno(...args: any[]): Promise<any>;

--- a/packages/types/src/shared/index.ts
+++ b/packages/types/src/shared/index.ts
@@ -28,7 +28,10 @@ export interface GerarConsultaImpl { gerarConsulta(...args: any[]): Promise<any>
 export interface HttpClient { get(...args: any[]): Promise<any>; post(...args: any[]): Promise<any>; }
 export interface HttpClientConfig { [key: string]: any; }
 export interface NFeWizardServiceImpl { [key: string]: any; }
-export interface NFEAutorizacaoServiceImpl { Exec(...args: any[]): Promise<any>; }
+export interface NFEAutorizacaoServiceImpl {
+    Exec(...args: any[]): Promise<any>;
+    ExecTransmitirContingencia?(...args: any[]): Promise<any>;
+}
 export interface NFEconsultaProtocoloServiceImpl { Exec(...args: any[]): Promise<any>; }
 export interface NFEDistribuicaoDFeServiceImpl { Exec(...args: any[]): Promise<any>; }
 export interface NFEInutilizacaoServiceImpl { Exec(...args: any[]): Promise<any>; }
@@ -38,7 +41,10 @@ export interface NFERetornoAutorizacaoServiceImpl {
     getXmlRetorno(...args: any[]): Promise<any>;
 }
 export interface NFEStatusServicoServiceImpl { Exec(...args: any[]): Promise<any>; }
-export interface NFCEAutorizacaoServiceImpl { Exec(...args: any[]): Promise<any>; }
+export interface NFCEAutorizacaoServiceImpl {
+    Exec(...args: any[]): Promise<any>;
+    ExecTransmitirContingencia?(...args: any[]): Promise<any>;
+}
 export interface NFCERetornoAutorizacaoServiceImpl { getXmlRetorno(...args: any[]): Promise<any>; }
 export interface NFSeAutorizacaoServiceImpl { Exec(...args: any[]): Promise<any>; }
 export interface CTEDistribuicaoDFeServiceImpl { Exec(...args: any[]): Promise<any>; }


### PR DESCRIPTION
## Contexto
A issue #90 apontou uma dúvida recorrente no fluxo de contingência offline da NFC-e: ao usar `tpEmis=9`, a etapa de autorização não faz envio imediato para a SEFAZ, e o envio posterior deve ocorrer por método específico.

## O que esta PR entrega
1. Documentação explícita do fluxo em 2 etapas:
   1. Emissão offline com `tpEmis=9`
   2. Retransmissão posterior quando a conexão voltar
2. Regras e validações obrigatórias para contingência:
   1. `tpEmis=9` somente para `mod=65`
   2. `dhCont` obrigatório em contingência
   3. `xJust` obrigatório com mínimo de 15 caracteres
3. Explicação do retorno esperado na etapa offline, incluindo status interno de contingência e uso do XML assinado para transmissão posterior.
4. Checklist rápido de homologação para testar emissão e retransmissão.
5. Exemplo prático atualizado com:
   1. Geração em contingência offline
   2. Chamada de retransmissão posterior com `NFCE_TransmitirContingencia`

## Motivação
Reduzir ambiguidade de uso e deixar claro que o comportamento atual é intencional e aderente à NT 2018.006.

## Escopo
1. Apenas documentação e exemplo de uso.
2. Sem alteração de API pública.
3. Sem alteração de comportamento de transmissão.

## Como validar
1. Executar o exemplo de NFC-e em homologação.
2. Confirmar que, com `tpEmis=9`, ocorre geração/assinatura local sem envio imediato.
3. Confirmar retransmissão posterior com `NFCE_TransmitirContingencia` e retorno de protocolo real da SEFAZ.

## Checklist
- [x] Não há breaking change.
- [x] Não há mudança funcional no core de autorização.
- [x] Documentação e exemplo alinhados ao comportamento atual do serviço.