### PR TITLE
fix(danfe): permite desabilitar a marca d'água na DANFE de NFC-e

### DIFF
--- a/.changeset/nfce-danfe-watermark-fix.md
+++ b/.changeset/nfce-danfe-watermark-fix.md
@@ -1,0 +1,5 @@
+---
+'@nfewizard/danfe': patch
+---
+
+Corrige a impossibilidade de desabilitar a marca d'água na DANFE de NFC-e. O método `NFCeGerarDanfe.generatePDF` usava `exibirMarcaDaguaDanfe || true`, o que forçava a marca d'água sempre ativa e ignorava o valor `false`. Passa a usar `?? true`, como já ocorre na DANFE de NF-e, permitindo desabilitar a marca d'água ao passar `false`.

--- a/packages/danfe/src/generators/NFCEGerarDanfe.ts
+++ b/packages/danfe/src/generators/NFCEGerarDanfe.ts
@@ -581,7 +581,7 @@ class NFCeGerarDanfe {
 
     async generatePDF(exibirMarcaDaguaDanfe?: boolean) {
         try {
-            this.exibirMarcaDaguaDanfe = exibirMarcaDaguaDanfe || true;
+            this.exibirMarcaDaguaDanfe = exibirMarcaDaguaDanfe ?? true;
 
             // await this.saveQRCode(this.infNFeSupl?.qrCode  || '')
             const qrCodeBuffer = await this.getQRCodeBuffer(this.infNFeSupl?.qrCode || '');


### PR DESCRIPTION
## Descrição

Corrige a impossibilidade de desabilitar a marca d'água na DANFE de **NFC-e**.

No método `NFCeGerarDanfe.generatePDF` (`packages/danfe/src/generators/NFCEGerarDanfe.ts`), a atribuição usava:

```ts
this.exibirMarcaDaguaDanfe = exibirMarcaDaguaDanfe || true;
```

Como `false || true` sempre resulta em `true`, passar `false` não tinha efeito e a marca d'água ficava **forçada** na DANFE de NFC-e, sem forma de removê-la.

## Correção

Troca `|| true` por `?? true`, exatamente como já é feito na DANFE de NF-e (`NFeGerarDanfe.generatePDF`):

```ts
this.exibirMarcaDaguaDanfe = exibirMarcaDaguaDanfe ?? true;
```

Assim, o padrão continua sendo exibir a marca d'água (quando o parâmetro é omitido/`undefined`), mas passar `false` volta a desabilitá-la corretamente.

## Observações

- Alteração mínima de uma linha; apenas a classe de NFC-e foi tocada (a de NF-e já estava correta e não foi alterada).
- Adicionado changeset (`patch`) para `@nfewizard/danfe`.

Closes #111
